### PR TITLE
Ajoute filtres annuels et graphiques aux bilans objets

### DIFF
--- a/BilanObjetsCollectes.php
+++ b/BilanObjetsCollectes.php
@@ -1,10 +1,158 @@
 <?php
 require('actions/users/securityAction.php');
-require('actions/objets/insertObjetDsDb.php');
-require('actions/objets/recupDb.php');
-require('actions/objets/getSommePoids.php');
-require('actions/objets/miseAJourDb.php');
+require('actions/db.php');
 
+/**
+ * Build a normalized key for a category name so that close names are grouped
+ * together.
+ */
+function normalizeCategoryKey(string $category): string
+{
+    $normalized = iconv('UTF-8', 'ASCII//TRANSLIT', $category);
+    if ($normalized === false) {
+        $normalized = $category;
+    }
+
+    $normalized = strtolower($normalized);
+    $normalized = preg_replace('/[^a-z0-9]+/u', '', $normalized);
+
+    if ($normalized === '') {
+        return 'non_renseigne';
+    }
+
+    $synonyms = [
+        'electromenager' => 'electromenager',
+        'electromenagers' => 'electromenager',
+        'electromenage' => 'electromenager',
+        'electromanager' => 'electromenager',
+        'vetements' => 'vetement',
+        'vetement' => 'vetement',
+        'veterements' => 'vetement',
+    ];
+
+    return $synonyms[$normalized] ?? $normalized;
+}
+
+/**
+ * Extract the year from a date stored in different textual formats.
+ */
+function extractYear(?string $rawDate): ?int
+{
+    if ($rawDate === null) {
+        return null;
+    }
+
+    $rawDate = trim($rawDate);
+    if ($rawDate === '') {
+        return null;
+    }
+
+    $formats = [
+        'Y-m-d H:i:s',
+        'Y-m-d H:i',
+        'Y-m-d',
+        'd/m/Y H:i:s',
+        'd/m/Y H:i',
+        'd/m/Y',
+        'd-m-Y',
+        'd-m-Y H:i',
+        'm/d/Y',
+        'd.m.Y',
+    ];
+
+    foreach ($formats as $format) {
+        $dateTime = DateTime::createFromFormat($format, $rawDate);
+        if ($dateTime instanceof DateTime) {
+            return (int) $dateTime->format('Y');
+        }
+    }
+
+    if (ctype_digit($rawDate) && strlen($rawDate) >= 10) {
+        $timestamp = (int) substr($rawDate, 0, 10);
+        $dateTime = (new DateTime())->setTimestamp($timestamp);
+        return (int) $dateTime->format('Y');
+    }
+
+    if (preg_match('/(19|20)\d{2}/', $rawDate, $matches)) {
+        return (int) $matches[0];
+    }
+
+    return null;
+}
+
+$statement = $db->query('SELECT id, nom, categorie, souscat, poids, date, flux FROM objets_collectes');
+$objetsCollectes = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+$years = [];
+foreach ($objetsCollectes as $index => $objet) {
+    $year = extractYear($objet['date']);
+    $objetsCollectes[$index]['_year'] = $year;
+    if ($year !== null) {
+        $years[$year] = true;
+    }
+}
+
+$availableYears = array_keys($years);
+rsort($availableYears);
+
+$selectedYear = null;
+if (isset($_GET['annee']) && $_GET['annee'] !== '') {
+    $candidateYear = filter_var($_GET['annee'], FILTER_VALIDATE_INT);
+    if ($candidateYear !== false && in_array($candidateYear, $availableYears, true)) {
+        $selectedYear = $candidateYear;
+    }
+}
+
+$filteredCollectes = array_filter($objetsCollectes, static function (array $objet) use ($selectedYear): bool {
+    if ($selectedYear === null) {
+        return true;
+    }
+
+    return $objet['_year'] === $selectedYear;
+});
+
+$totalWeightGrams = 0;
+$categories = [];
+
+foreach ($filteredCollectes as $objet) {
+    $poids = (float) $objet['poids'];
+    $totalWeightGrams += $poids;
+
+    $categoryKey = normalizeCategoryKey($objet['categorie'] ?? '');
+    $label = trim((string) ($objet['categorie'] ?? ''));
+    if ($label === '') {
+        $label = 'Non renseigné';
+    }
+
+    if (!isset($categories[$categoryKey])) {
+        $categories[$categoryKey] = [
+            'total' => 0.0,
+            'labels' => [],
+        ];
+    }
+
+    $categories[$categoryKey]['total'] += $poids;
+    $categories[$categoryKey]['labels'][$label] = ($categories[$categoryKey]['labels'][$label] ?? 0) + 1;
+}
+
+foreach ($categories as $key => $category) {
+    arsort($category['labels']);
+    $categories[$key]['display'] = (string) array_key_first($category['labels']);
+}
+
+usort($categories, static function (array $a, array $b): int {
+    return $b['total'] <=> $a['total'];
+});
+
+$chartLabels = [];
+$chartData = [];
+
+foreach ($categories as $category) {
+    $chartLabels[] = $category['display'];
+    $chartData[] = round($category['total'] / 1000, 3);
+}
+
+$totalWeightKg = $totalWeightGrams / 1000;
 ?>
 
 
@@ -22,105 +170,111 @@ require('actions/objets/miseAJourDb.php');
             $page = 3;
             include("includes/nav.php");
             ?>
-            
-            
+
+
             <?php
             if($_SESSION['admin'] >= 1){
             ?>
-        
-        
+
+
         <?php if(isset($message)){
             echo '<p style="text-align: center;">'.$message.'</p>';
         }
         ?>
-        
-        <p style="text-align: center;"> Poids Total d'objets <b>collectés</b> toute catégorie confondue : <?php
-        $poids_total_obj_collecte_kg = $poids_total_obj_collecte['poids_total']/1000;
-        echo $poids_total_obj_collecte_kg.' Kg';
-        ?> </p>
-        
-        <form method="get">
-                
-                <fieldset class="jeuchamp">
-            
-                    <label class="champ" for="tri">Trier par : </label>
-                    <select id="tri" name="tri">
-                        <option value="nom">Nom</option>
-                        <option value="categorie">Catégorie</option>
-                        <option value="poids">Poids</option>
-                        <option value="timestamp">Date d'ajout</option>
-                    </select>
-                
-                </fieldset>
-            
-                <input type="submit" class="input inputsubmit" name="validate" value="Trier">
-        </form>
-        
-        <table class="tableau">
-            <tr class="ligne">
-                <th class="cellule_tete">Categories</th>
-                <th class="cellule_tete">Poids total</th>
-                <th class="cellule_tete">Pourcentage</th>
-            </tr>
-            
-        <?php
-        
-        foreach($LesSommes as list($categorie, $poids_total_par_cat)){
-            $poids_total_par_cat_kg = $poids_total_par_cat/1000;
-            $pourcentage = round((($poids_total_par_cat_kg * 100) / $poids_total_obj_collecte_kg),1);
-            echo '<tr class="ligne">
-                        
-                            <td class="colonne">'.$categorie.'</td>
-                            <td class="colonne">'.$poids_total_par_cat_kg.' kg</td>
-                            <td class="colonne">'.$pourcentage.'%</td> 
 
-                          </tr>'  ;
-        }
-        ?>
-            
-            
-        </table>
-        
-        
-        <table class="tableau">
-            <tr class="ligne">
-                <th class="cellule_tete">Id</th>
-                <th class="cellule_tete">flux</th>
-                <th class="cellule_tete">Catégorie</th>
-                <th class="cellule_tete">Sous-Catégorie</th>
-                <th class="cellule_tete">Précision</th>
-                <th class="cellule_tete">Poids en gramme</th>
-                <th class="cellule_tete">Date d'insertion</th>
-                
-            </tr>
-        
-        <?php foreach($getObjets as list($id, $nom, $type, $souscat, $poids, $date, $timestamp, $flux)){
-                    
-        
-                        echo '<tr class="ligne">
-                        
-                            <td class="colonne">'.$id.'</td>
-                            <td class="colonne">'.$flux.'</td>
-                            <td class="colonne">'.$type.'</td>
-                            <td class="colonne">'.$souscat.'</td>
-                            <td class="colonne">'.$nom.'</td>
-                            <td class="colonne">'.$poids.'</td>
-                            <td class="colonne">'.$date.'</td>
-                            
-                            <td class="colonne"><a href="modifObjet.php?id='.$id.'">Modifier</a></td>
-                            
-                            <td class="colonne"><a href="actions/objets/supprObjetAction.php?id='.$id.'">Supprimer</a></td>
-                            
-                          </tr>'  ;
-        }
-        ?>
-        </table>
-        
+        <section style="text-align: center;">
+            <p>Poids total d'objets <strong>collectés</strong> pour
+                <?php echo $selectedYear === null ? 'toutes les années' : 'l&#039;année '.$selectedYear; ?> :
+                <strong><?php echo number_format($totalWeightKg, 2, ',', ' '); ?> kg</strong>
+            </p>
+        </section>
+
+        <form method="get" class="jeuchamp" style="margin: 1.5rem auto; max-width: 420px;">
+            <label class="champ" for="annee">Filtrer par année :</label>
+            <select id="annee" name="annee" class="input">
+                <option value="">Toutes les années</option>
+                <?php foreach ($availableYears as $yearOption): ?>
+                    <option value="<?php echo htmlspecialchars((string) $yearOption, ENT_QUOTES); ?>" <?php echo $selectedYear === (int) $yearOption ? 'selected' : ''; ?>>
+                        <?php echo htmlspecialchars((string) $yearOption, ENT_QUOTES); ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+            <button type="submit" class="input inputsubmit" style="margin-top: 1rem;">Actualiser</button>
+        </form>
+
+        <?php if ($totalWeightGrams === 0): ?>
+            <p style="text-align: center;">Aucune donnée disponible pour la période sélectionnée.</p>
+        <?php else: ?>
+            <div style="max-width: 960px; margin: 0 auto 2rem;">
+                <table class="tableau">
+                    <tr class="ligne">
+                        <th class="cellule_tete">Catégorie</th>
+                        <th class="cellule_tete">Poids total (kg)</th>
+                        <th class="cellule_tete">Répartition</th>
+                    </tr>
+                    <?php foreach ($categories as $category):
+                        $poidsKg = $category['total'] / 1000;
+                        $pourcentage = $totalWeightGrams > 0 ? ($poidsKg * 100) / $totalWeightKg : 0;
+                    ?>
+                        <tr class="ligne">
+                            <td class="colonne"><?php echo htmlspecialchars($category['display'], ENT_QUOTES); ?></td>
+                            <td class="colonne"><?php echo number_format($poidsKg, 2, ',', ' '); ?></td>
+                            <td class="colonne"><?php echo number_format($pourcentage, 1, ',', ' '); ?>%</td>
+                        </tr>
+                    <?php endforeach; ?>
+                </table>
+            </div>
+
+            <div style="max-width: 640px; margin: 0 auto 3rem;">
+                <canvas id="collectesPie"></canvas>
+            </div>
+        <?php endif; ?>
+
         <?php
             }else{
                 echo 'Vous n\'êtes pas administrateur, veuillez contacter le webmaster svp';
             }
             include('includes/footer.php');
             ?>
+
+        <?php if ($totalWeightGrams > 0): ?>
+            <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+            <script>
+                const collectesLabels = <?php echo json_encode($chartLabels, JSON_UNESCAPED_UNICODE); ?>;
+                const collectesData = <?php echo json_encode($chartData, JSON_UNESCAPED_UNICODE); ?>;
+
+                const ctx = document.getElementById('collectesPie');
+                if (ctx) {
+                    new Chart(ctx, {
+                        type: 'pie',
+                        data: {
+                            labels: collectesLabels,
+                            datasets: [{
+                                data: collectesData,
+                                backgroundColor: [
+                                    '#f94144', '#f3722c', '#f8961e', '#f9844a', '#f9c74f',
+                                    '#90be6d', '#43aa8b', '#4d908e', '#577590', '#277da1'
+                                ],
+                            }]
+                        },
+                        options: {
+                            plugins: {
+                                legend: {
+                                    position: 'bottom'
+                                },
+                                tooltip: {
+                                    callbacks: {
+                                        label: (context) => {
+                                            const value = Number(context.parsed ?? 0);
+                                            return `${context.label}: ${value.toLocaleString('fr-FR', {minimumFractionDigits: 2, maximumFractionDigits: 2})} kg`;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    });
+                }
+            </script>
+        <?php endif; ?>
     </body>
 </html>

--- a/BilanObjetsVendus.php
+++ b/BilanObjetsVendus.php
@@ -1,10 +1,151 @@
 <?php
 require('actions/users/securityAction.php');
-require('actions/objets/recupDBvendus.php');
+require('actions/db.php');
 
-require('actions/objets/getSommePrixVendus.php');
+function normalizeCategoryKey(string $category): string
+{
+    $normalized = iconv('UTF-8', 'ASCII//TRANSLIT', $category);
+    if ($normalized === false) {
+        $normalized = $category;
+    }
 
+    $normalized = strtolower($normalized);
+    $normalized = preg_replace('/[^a-z0-9]+/u', '', $normalized);
 
+    if ($normalized === '') {
+        return 'non_renseigne';
+    }
+
+    $synonyms = [
+        'electromenager' => 'electromenager',
+        'electromenagers' => 'electromenager',
+        'electromenage' => 'electromenager',
+        'electromanager' => 'electromenager',
+        'vetements' => 'vetement',
+        'vetement' => 'vetement',
+        'veterements' => 'vetement',
+    ];
+
+    return $synonyms[$normalized] ?? $normalized;
+}
+
+function extractYear(?string $rawDate): ?int
+{
+    if ($rawDate === null) {
+        return null;
+    }
+
+    $rawDate = trim($rawDate);
+    if ($rawDate === '') {
+        return null;
+    }
+
+    $formats = [
+        'Y-m-d H:i:s',
+        'Y-m-d H:i',
+        'Y-m-d',
+        'd/m/Y H:i:s',
+        'd/m/Y H:i',
+        'd/m/Y',
+        'd-m-Y',
+        'd-m-Y H:i',
+        'm/d/Y',
+        'd.m.Y',
+    ];
+
+    foreach ($formats as $format) {
+        $dateTime = DateTime::createFromFormat($format, $rawDate);
+        if ($dateTime instanceof DateTime) {
+            return (int) $dateTime->format('Y');
+        }
+    }
+
+    if (ctype_digit($rawDate) && strlen($rawDate) >= 10) {
+        $timestamp = (int) substr($rawDate, 0, 10);
+        $dateTime = (new DateTime())->setTimestamp($timestamp);
+        return (int) $dateTime->format('Y');
+    }
+
+    if (preg_match('/(19|20)\d{2}/', $rawDate, $matches)) {
+        return (int) $matches[0];
+    }
+
+    return null;
+}
+
+$statement = $db->query('SELECT nom, nom_vendeur, categorie, souscat, date_achat, prix FROM objets_vendus');
+$objetsVendus = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+$years = [];
+foreach ($objetsVendus as $index => $objet) {
+    $year = extractYear($objet['date_achat']);
+    $objetsVendus[$index]['_year'] = $year;
+    if ($year !== null) {
+        $years[$year] = true;
+    }
+}
+
+$availableYears = array_keys($years);
+rsort($availableYears);
+
+$selectedYear = null;
+if (isset($_GET['annee']) && $_GET['annee'] !== '') {
+    $candidateYear = filter_var($_GET['annee'], FILTER_VALIDATE_INT);
+    if ($candidateYear !== false && in_array($candidateYear, $availableYears, true)) {
+        $selectedYear = $candidateYear;
+    }
+}
+
+$filteredVentes = array_filter($objetsVendus, static function (array $objet) use ($selectedYear): bool {
+    if ($selectedYear === null) {
+        return true;
+    }
+
+    return $objet['_year'] === $selectedYear;
+});
+
+$totalPriceCents = 0;
+$categories = [];
+
+foreach ($filteredVentes as $vente) {
+    $prix = (float) $vente['prix'];
+    $totalPriceCents += $prix;
+
+    $categoryKey = normalizeCategoryKey($vente['categorie'] ?? '');
+    $label = trim((string) ($vente['categorie'] ?? ''));
+    if ($label === '') {
+        $label = 'Non renseigné';
+    }
+
+    if (!isset($categories[$categoryKey])) {
+        $categories[$categoryKey] = [
+            'total' => 0.0,
+            'labels' => [],
+        ];
+    }
+
+    $categories[$categoryKey]['total'] += $prix;
+    $categories[$categoryKey]['labels'][$label] = ($categories[$categoryKey]['labels'][$label] ?? 0) + 1;
+}
+
+foreach ($categories as $key => $category) {
+    arsort($category['labels']);
+    $categories[$key]['display'] = (string) array_key_first($category['labels']);
+}
+
+usort($categories, static function (array $a, array $b): int {
+    return $b['total'] <=> $a['total'];
+});
+
+$chartLabels = [];
+$chartData = [];
+
+foreach ($categories as $category) {
+    $chartLabels[] = $category['display'];
+    $chartData[] = round($category['total'] / 100, 2);
+}
+
+$totalPriceEuro = $totalPriceCents / 100;
 ?>
 
 <!DOCTYPE HTML>
@@ -21,103 +162,111 @@ require('actions/objets/getSommePrixVendus.php');
             $page = 3;
             include("includes/nav.php");
             ?>
-            
-            
+
+
             <?php
             if($_SESSION['admin'] >= 1){
             ?>
-            
-             
-        
-        
+
+
         <?php if(isset($message)){
             echo '<p style="text-align: center;">'.$message.'</p>';
         }
         ?>
-        
-        <p style="text-align: center;"> Prix Total d'objets <b>vendus</b> toute catégorie confondue : <?php
-        $prix_total_obj_collecte_kg = $prix_total_obj_collecte['prix_total']/100;
-        echo $prix_total_obj_collecte_kg.' €';
-        ?> </p>
-        
-        <form method="get">
-                
-                <fieldset class="jeuchamp">
-            
-                    <label class="champ" for="tri">Trier par : </label>
-                    <select id="tri" name="tri">
-                        <option value="nom">Nom</option>
-                        <option value="categorie">Catégorie</option>
-                        <option value="prix">Prix</option>
-                        <option value="timestamp">Date d'ajout</option>
-                    </select>
-                
-                </fieldset>
-            
-                <input type="submit" class="input inputsubmit" name="validate" value="Trier">
+
+        <section style="text-align: center;">
+            <p>Montant total des objets <strong>vendus</strong> pour
+                <?php echo $selectedYear === null ? 'toutes les années' : 'l&#039;année '.$selectedYear; ?> :
+                <strong><?php echo number_format($totalPriceEuro, 2, ',', ' '); ?> €</strong>
+            </p>
+        </section>
+
+        <form method="get" class="jeuchamp" style="margin: 1.5rem auto; max-width: 420px;">
+            <label class="champ" for="annee">Filtrer par année :</label>
+            <select id="annee" name="annee" class="input">
+                <option value="">Toutes les années</option>
+                <?php foreach ($availableYears as $yearOption): ?>
+                    <option value="<?php echo htmlspecialchars((string) $yearOption, ENT_QUOTES); ?>" <?php echo $selectedYear === (int) $yearOption ? 'selected' : ''; ?>>
+                        <?php echo htmlspecialchars((string) $yearOption, ENT_QUOTES); ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+            <button type="submit" class="input inputsubmit" style="margin-top: 1rem;">Actualiser</button>
         </form>
-        
-        <table class="tableau">
-            <tr class="ligne">
-                <th class="cellule_tete">Categories</th>
-                <th class="cellule_tete">Prix total</th>
-                <th class="cellule_tete">Pourcentage</th>
-            </tr>
-            
-        <?php
-        
-        foreach($LesSommes as list($categorie, $prix_total_par_cat)){
-            $prix_total_par_cat_euro = $prix_total_par_cat/100;
-            $pourcentage = round((($prix_total_par_cat_euro * 100) / $prix_total_obj_collecte_kg),1);
-            echo '<tr class="ligne">
-                        
-                            <td class="colonne">'.$categorie.'</td>
-                            <td class="colonne">'.$prix_total_par_cat_euro.' €</td>
-                            <td class="colonne">'.$pourcentage.'%</td>         
-                          </tr>'  ;
-        }
-        ?>
-           
-            
-        </table>
-        
-        
-        <table class="tableau">
-            <tr class="ligne">
-    
-                <th class="cellule_tete">Nom</th>
-                <th class="cellule_tete">Nom du vendeur</th>
-                <th class="cellule_tete">Catégorie</th>
-                <th class="cellule_tete">Sous-Catégorie</th>
-                <th class="cellule_tete">Date de vente</th>
-                <th class="cellule_tete">Prix en €</th>
-            </tr>
-        
-        <?php foreach($getObjets as list($nom, $nom_vendeur, $type, $souscat, $date_vente, $timestamp, $prix)){
-            
-                        $prixeuro = $prix/100;
-        
-                        echo '<tr class="ligne">
-                        
-                            
-                            <td class="colonne">'.$nom.'</td>
-                            <td class="colonne">'.$nom_vendeur.'</td>
-                            <td class="colonne">'.$type.'</td>
-                            <td class="colonne">'.$souscat.'</td>
-                            <td class="colonne">'.$date_vente.'</td>
-                            <td class="colonne">'.$prixeuro.'€</td>
-                            
-                            
-                          </tr>'  ;
-        }
-        ?>
-        </table>
-        
+
+        <?php if ($totalPriceCents === 0): ?>
+            <p style="text-align: center;">Aucune donnée disponible pour la période sélectionnée.</p>
+        <?php else: ?>
+            <div style="max-width: 960px; margin: 0 auto 2rem;">
+                <table class="tableau">
+                    <tr class="ligne">
+                        <th class="cellule_tete">Catégorie</th>
+                        <th class="cellule_tete">Montant total (€)</th>
+                        <th class="cellule_tete">Répartition</th>
+                    </tr>
+                    <?php foreach ($categories as $category):
+                        $montantEuro = $category['total'] / 100;
+                        $pourcentage = $totalPriceEuro > 0 ? ($montantEuro * 100) / $totalPriceEuro : 0;
+                    ?>
+                        <tr class="ligne">
+                            <td class="colonne"><?php echo htmlspecialchars($category['display'], ENT_QUOTES); ?></td>
+                            <td class="colonne"><?php echo number_format($montantEuro, 2, ',', ' '); ?></td>
+                            <td class="colonne"><?php echo number_format($pourcentage, 1, ',', ' '); ?>%</td>
+                        </tr>
+                    <?php endforeach; ?>
+                </table>
+            </div>
+
+            <div style="max-width: 640px; margin: 0 auto 3rem;">
+                <canvas id="ventesPie"></canvas>
+            </div>
+        <?php endif; ?>
+
         <?php
             }else{
                 echo 'Vous n\'êtes pas administrateur, veuillez contacter le webmaster svp';
             }
             include('includes/footer.php');
             ?>
+
+        <?php if ($totalPriceCents > 0): ?>
+            <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+            <script>
+                const ventesLabels = <?php echo json_encode($chartLabels, JSON_UNESCAPED_UNICODE); ?>;
+                const ventesData = <?php echo json_encode($chartData, JSON_UNESCAPED_UNICODE); ?>;
+
+                const ctx = document.getElementById('ventesPie');
+                if (ctx) {
+                    new Chart(ctx, {
+                        type: 'pie',
+                        data: {
+                            labels: ventesLabels,
+                            datasets: [{
+                                data: ventesData,
+                                backgroundColor: [
+                                    '#577590', '#277da1', '#4d908e', '#43aa8b', '#90be6d',
+                                    '#f9c74f', '#f9844a', '#f8961e', '#f3722c', '#f94144'
+                                ],
+                            }]
+                        },
+                        options: {
+                            plugins: {
+                                legend: {
+                                    position: 'bottom'
+                                },
+                                tooltip: {
+                                    callbacks: {
+                                        label: (context) => {
+                                            const value = Number(context.parsed ?? 0);
+                                            return `${context.label}: ${value.toLocaleString('fr-FR', {minimumFractionDigits: 2, maximumFractionDigits: 2})} €`;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    });
+                }
+            </script>
+        <?php endif; ?>
     </body>
 </html>


### PR DESCRIPTION
## Summary
- refond les pages de bilan pour les collectes et les ventes afin d'utiliser les données directement depuis la base
- ajoute un filtrage par année et un regroupement intelligent des catégories pour consolider l'affichage
- affiche des tableaux synthétiques et des graphiques camembert Chart.js pour visualiser les répartitions

## Testing
- php -l BilanObjetsCollectes.php
- php -l BilanObjetsVendus.php

------
https://chatgpt.com/codex/tasks/task_e_68e7beb6fff083278883b90c0fd79b1b