### PR TITLE
Improve PHP 8.4 compatibility

### DIFF
--- a/actions/db.php
+++ b/actions/db.php
@@ -1,7 +1,7 @@
 <?php
 
 // Détection automatique de l'environnement
-$host = $_SERVER['HTTP_HOST'];
+$host = $_SERVER['HTTP_HOST'] ?? '';
 
 if ($host === 'bdd' || $host === '127.0.0.1') {
     // Mode développement

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -2,6 +2,10 @@
 
 
 
+if (function_exists('date_default_timezone_set') && !ini_get('date.timezone')) {
+    date_default_timezone_set('UTC');
+}
+
 function get_pdo (): PDO {
     /* $dbname = "09007_ressourceb";
     $serveur = "sql01.ouvaton.coop";
@@ -12,7 +16,9 @@ function get_pdo (): PDO {
     $login = "418153";
     $pass = "geMsos-wunxoc-1fucbu";
 
-    if($_SERVER['HTTP_HOST']=='localhost:8888'):
+    $httpHost = $_SERVER['HTTP_HOST'] ?? '';
+
+    if($httpHost=='localhost:8888'):
 
         return new PDO("mysql:host=localhost;dbname=objets;charset=utf8;", "root", "root", [
             PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
+        "php": "^8.2 || ^8.3 || ^8.4",
         "twbs/bootstrap": "5.3.0-alpha2",
         "setasign/fpdf": "^1.8",
         "setasign/fpdi": "^2.6"


### PR DESCRIPTION
## Summary
- declare PHP 8.2-8.4 support in Composer to surface version expectations
- guard HTTP_HOST usage to avoid undefined index notices in PHP 8.4
- set a default timezone when none is configured to prevent runtime warnings

## Testing
- php -l app/bootstrap.php
- php -l actions/db.php
- composer validate *(fails: project metadata missing and lockfile outdated; packagist access blocked in sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c1f9558048327bc545a21ea16b982)