### PR TITLE
Add PDF export for session_caisse écarts and refactor helpers

### DIFF
--- a/actions/comptabilite/generateComptabilitePdf.php
+++ b/actions/comptabilite/generateComptabilitePdf.php
@@ -1,0 +1,159 @@
+<?php
+require('../users/securityAction.php');
+require('../db.php');
+require('sessionCaisseHelpers.php');
+require(__DIR__ . '/../../app/models/fpdf/fpdf/src/Fpdf/Fpdf.php');
+
+if ($_SESSION['admin'] < 1) {
+    echo 'Vous n\'êtes pas administrateur, veuillez contacter le webmaster svp.';
+    exit;
+}
+
+$columns = [];
+$dateColumn = null;
+$ecartColumn = null;
+$errors = [];
+$rows = [];
+$years = [];
+$selectedYear = null;
+
+try {
+    $columns = getSessionCaisseColumns($db);
+    $columnNames = array_column($columns, 'Field');
+    $dateColumn = findSessionCaisseDateColumn($columnNames);
+    $ecartColumn = findSessionCaisseEcartColumn($columnNames);
+
+    if (!$ecartColumn) {
+        $errors[] = "La colonne 'ecart' est introuvable dans la table session_caisse.";
+    }
+
+    if ($dateColumn) {
+        $years = getSessionCaisseYears($db, $dateColumn);
+        if (isset($_GET['year'])) {
+            $selectedYear = (int) $_GET['year'];
+        } elseif (!empty($years)) {
+            $selectedYear = (int) $years[0];
+        } else {
+            $selectedYear = (int) date('Y');
+        }
+
+        if ($selectedYear) {
+            $rows = getSessionCaisseRowsForYear($db, $dateColumn, $selectedYear);
+        }
+    } else {
+        $errors[] = "Aucune colonne de date n'a été trouvée pour filtrer par année.";
+    }
+} catch (Exception $exception) {
+    $errors[] = 'Impossible de récupérer les sessions de caisse : ' . $exception->getMessage();
+}
+
+if (!empty($errors)) {
+    echo implode('<br>', array_map('htmlspecialchars', $errors));
+    exit;
+}
+
+if (!$ecartColumn || !$dateColumn) {
+    echo 'Impossible de générer le PDF : colonnes manquantes.';
+    exit;
+}
+
+$rowsWithEcart = array_filter($rows, fn($row) => (float) ($row[$ecartColumn] ?? 0) !== 0.0);
+$rowsWithEcart = array_values($rowsWithEcart);
+
+$recap = buildEcartRecap($rowsWithEcart, $ecartColumn);
+$recapNet = $recap['positive'] + $recap['negative'];
+$sessionCount = count($rows);
+$sessionCountWithEcart = count($rowsWithEcart);
+
+function pdfText(string $text): string
+{
+    return iconv('UTF-8', 'ISO-8859-1//TRANSLIT', $text);
+}
+
+$pdf = new FPDF('P', 'mm', 'A4');
+$pdf->SetTitle(pdfText('Bilan des sessions de caisse'));
+$pdf->SetAuthor(pdfText("La Ressourcerie de Brie"));
+$pdf->AddPage();
+
+$pdf->SetFont('Arial', 'B', 16);
+$pdf->Cell(0, 10, pdfText('Bilan des sessions de caisse'), 0, 1, 'C');
+$pdf->SetFont('Arial', '', 11);
+$pdf->Cell(0, 6, pdfText('Année : ' . $selectedYear), 0, 1, 'C');
+$pdf->Cell(0, 6, pdfText('Date de génération : ' . date('d/m/Y')), 0, 1, 'C');
+$pdf->Ln(4);
+
+$pdf->SetFont('Arial', 'B', 12);
+$pdf->Cell(0, 8, pdfText('Récapitulatif des écarts (sessions avec écart uniquement)'), 0, 1, 'L');
+
+$pdf->SetFont('Arial', '', 11);
+$pdf->Cell(70, 8, pdfText('Total des écarts négatifs'), 1, 0, 'L');
+$pdf->Cell(60, 8, pdfText('Total des écarts positifs'), 1, 0, 'L');
+$pdf->Cell(60, 8, pdfText('Nombre de sessions'), 1, 1, 'L');
+$pdf->Cell(70, 8, pdfText(formatEcartValue($recap['negative'])), 1, 0, 'L');
+$pdf->Cell(60, 8, pdfText(formatEcartValue($recap['positive'])), 1, 0, 'L');
+$pdf->Cell(60, 8, pdfText((string) $sessionCountWithEcart), 1, 1, 'L');
+
+$pdf->Ln(4);
+$pdf->Cell(70, 8, pdfText('Écart net'), 1, 0, 'L');
+$pdf->Cell(60, 8, pdfText('Total sessions année'), 1, 0, 'L');
+$pdf->Cell(60, 8, pdfText('Sessions sans écart'), 1, 1, 'L');
+$pdf->Cell(70, 8, pdfText(formatEcartValue($recapNet)), 1, 0, 'L');
+$pdf->Cell(60, 8, pdfText((string) $sessionCount), 1, 0, 'L');
+$pdf->Cell(60, 8, pdfText((string) ($sessionCount - $sessionCountWithEcart)), 1, 1, 'L');
+
+$pdf->Ln(8);
+
+$pdf->SetFont('Arial', 'B', 12);
+$pdf->Cell(0, 8, pdfText('Détail des sessions avec écart'), 0, 1, 'L');
+$pdf->SetFont('Arial', 'B', 10);
+
+$columnNames = array_column($columns, 'Field');
+$displayColumns = [];
+foreach (['id_session', 'id', 'uuid_session'] as $possibleIdColumn) {
+    if (in_array($possibleIdColumn, $columnNames, true)) {
+        $displayColumns[] = $possibleIdColumn;
+        break;
+    }
+}
+$displayColumns[] = $dateColumn;
+$displayColumns[] = $ecartColumn;
+foreach (['caisse', 'utilisateur', 'nom_utilisateur', 'responsable'] as $possibleExtraColumn) {
+    if (in_array($possibleExtraColumn, $columnNames, true)) {
+        $displayColumns[] = $possibleExtraColumn;
+        break;
+    }
+}
+
+$columnWidths = [30, 45, 35, 60];
+$columnLabels = [];
+foreach ($displayColumns as $index => $columnName) {
+    $columnLabels[] = ucwords(str_replace('_', ' ', $columnName));
+}
+
+foreach ($displayColumns as $index => $columnName) {
+    $width = $columnWidths[$index] ?? 40;
+    $pdf->Cell($width, 7, pdfText($columnLabels[$index]), 1, 0, 'L');
+}
+$pdf->Ln();
+
+$pdf->SetFont('Arial', '', 9);
+if (empty($rowsWithEcart)) {
+    $pdf->Cell(0, 6, pdfText('Aucune session avec écart pour cette année.'), 1, 1, 'L');
+} else {
+    foreach ($rowsWithEcart as $row) {
+        foreach ($displayColumns as $index => $columnName) {
+            $width = $columnWidths[$index] ?? 40;
+            $value = $row[$columnName] ?? '';
+            $pdf->Cell($width, 6, pdfText((string) $value), 1, 0, 'L');
+        }
+        $pdf->Ln();
+    }
+}
+
+$pdf->Ln(10);
+$pdf->SetFont('Arial', '', 11);
+$pdf->Cell(90, 20, pdfText('Signature Trésorier'), 1, 0, 'L');
+$pdf->Cell(90, 20, pdfText('Signature Président'), 1, 1, 'L');
+
+$filename = 'bilan_sessions_caisse_' . $selectedYear . '.pdf';
+$pdf->Output('D', $filename);

--- a/actions/comptabilite/generateComptabilitePdf.php
+++ b/actions/comptabilite/generateComptabilitePdf.php
@@ -2,7 +2,8 @@
 require('../users/securityAction.php');
 require('../db.php');
 require('sessionCaisseHelpers.php');
-require __DIR__ . '/../../vendor/autoload.php';
+require(__DIR__ . '/../../vendor/autoload.php');
+
 if ($_SESSION['admin'] < 1) {
     echo 'Vous n\'êtes pas administrateur, veuillez contacter le webmaster svp.';
     exit;
@@ -85,8 +86,8 @@ function pdfText(string $text): string
 }
 
 $pdf = new FPDF('P', 'mm', 'A4');
-$pdf->SetTitle(pdfText('Bilan des sessions de caisse'));
-$pdf->SetAuthor(pdfText("La Ressourcerie de Brie"));
+$pdf->SetTitle(pdfText('Bilan des sessions de caisse'), false);
+$pdf->SetAuthor(pdfText("La Ressourcerie de Brie"), false);
 $pdf->AddPage();
 
 $pdf->SetFont('Arial', 'B', 16);
@@ -197,4 +198,7 @@ $pdf->Cell(90, 20, pdfText('Signature Trésorier'), 1, 0, 'L');
 $pdf->Cell(90, 20, pdfText('Signature Président'), 1, 1, 'L');
 
 $filename = 'bilan_sessions_caisse_' . $selectedYear . '.pdf';
+if (ob_get_length()) {
+    ob_end_clean();
+}
 $pdf->Output('D', $filename);

--- a/actions/comptabilite/generateComptabilitePdf.php
+++ b/actions/comptabilite/generateComptabilitePdf.php
@@ -2,8 +2,7 @@
 require('../users/securityAction.php');
 require('../db.php');
 require('sessionCaisseHelpers.php');
-require(__DIR__ . '/../../app/models/fpdf/fpdf/src/Fpdf/Fpdf.php');
-
+require __DIR__ . '/../../vendor/autoload.php';
 if ($_SESSION['admin'] < 1) {
     echo 'Vous n\'êtes pas administrateur, veuillez contacter le webmaster svp.';
     exit;

--- a/actions/comptabilite/sessionCaisseHelpers.php
+++ b/actions/comptabilite/sessionCaisseHelpers.php
@@ -1,0 +1,78 @@
+<?php
+
+function getSessionCaisseColumns(PDO $db): array
+{
+    return $db->query('SHOW COLUMNS FROM session_caisse')->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function findSessionCaisseDateColumn(array $columnNames): ?string
+{
+    $possibleDateColumns = ['date_session', 'date_fermeture', 'date_ouverture', 'date', 'created_at', 'updated_at'];
+    foreach ($possibleDateColumns as $possibleDateColumn) {
+        if (in_array($possibleDateColumn, $columnNames, true)) {
+            return $possibleDateColumn;
+        }
+    }
+
+    foreach ($columnNames as $columnName) {
+        if (stripos($columnName, 'date') !== false) {
+            return $columnName;
+        }
+    }
+
+    return null;
+}
+
+function findSessionCaisseEcartColumn(array $columnNames): ?string
+{
+    foreach ($columnNames as $columnName) {
+        if (stripos($columnName, 'ecart') !== false) {
+            return $columnName;
+        }
+    }
+
+    return null;
+}
+
+function getSessionCaisseYears(PDO $db, string $dateColumn): array
+{
+    $yearQuery = $db->query("SELECT DISTINCT YEAR($dateColumn) AS annee FROM session_caisse WHERE $dateColumn IS NOT NULL ORDER BY annee DESC");
+    $years = $yearQuery->fetchAll(PDO::FETCH_COLUMN);
+
+    return array_values(array_filter($years, fn($year) => $year !== null));
+}
+
+function getSessionCaisseRowsForYear(PDO $db, string $dateColumn, int $year): array
+{
+    $sql = "SELECT * FROM session_caisse WHERE YEAR($dateColumn) = :year ORDER BY $dateColumn DESC";
+    $statement = $db->prepare($sql);
+    $statement->execute(['year' => $year]);
+
+    return $statement->fetchAll(PDO::FETCH_ASSOC);
+}
+
+function buildEcartRecap(array $rows, string $ecartColumn): array
+{
+    $recap = [
+        'negative' => 0,
+        'positive' => 0,
+        'count' => 0,
+    ];
+
+    foreach ($rows as $row) {
+        $ecartValue = isset($row[$ecartColumn]) ? (float) $row[$ecartColumn] : 0;
+        if ($ecartValue < 0) {
+            $recap['negative'] += $ecartValue;
+        } elseif ($ecartValue > 0) {
+            $recap['positive'] += $ecartValue;
+        }
+        $recap['count'] += 1;
+    }
+
+    return $recap;
+}
+
+function formatEcartValue(float $value): string
+{
+    return number_format($value, 2, ',', ' ');
+}

--- a/actions/comptabilite/sessionCaisseHelpers.php
+++ b/actions/comptabilite/sessionCaisseHelpers.php
@@ -7,7 +7,11 @@ function getSessionCaisseColumns(PDO $db): array
 
 function findSessionCaisseDateColumn(array $columnNames): ?string
 {
-    $possibleDateColumns = ['date_session', 'date_fermeture', 'date_ouverture', 'date', 'created_at', 'updated_at'];
+    if (in_array('opened_at_utc', $columnNames, true)) {
+        return 'opened_at_utc';
+    }
+
+    $possibleDateColumns = ['opened_at_utc', 'date_session', 'date_fermeture', 'date_ouverture', 'date', 'created_at', 'updated_at'];
     foreach ($possibleDateColumns as $possibleDateColumn) {
         if (in_array($possibleDateColumn, $columnNames, true)) {
             return $possibleDateColumn;

--- a/administration.php
+++ b/administration.php
@@ -1,0 +1,32 @@
+<?php
+require('actions/users/securityAction.php');
+?>
+
+<!DOCTYPE HTML>
+
+<html lang="fr-FR">
+    <?php include("includes/head.php");?>
+    <body class="corps">
+        <?php
+            $lineheight = "uneligne";
+            $src = 'image/PictoFete.gif';
+            $alt = 'un oiseau qui fait la fête.';
+            $titre = 'Administration';
+            include("includes/header.php");
+            $page = 5;
+            include("includes/nav.php");
+        ?>
+
+        <?php if($_SESSION['admin'] >= 1): ?>
+            <div class="doc">
+                <ul class="doc_ul">
+                    <a class="doc_lien" href="comptabilite.php"><li class="doc_li" id="bleu">Comptabilité</li></a>
+                </ul>
+            </div>
+        <?php else: ?>
+            <p>Vous n'êtes pas administrateur, veuillez contacter le webmaster svp.</p>
+        <?php endif; ?>
+
+        <?php include('includes/footer.php'); ?>
+    </body>
+</html>

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bcbe5b438a7e875fdf571d0e0dd9ca12",
+    "content-hash": "fff70ee2991550a6ba3327ff09f60832",
     "packages": [
         {
             "name": "setasign/fpdf",
@@ -179,7 +179,9 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": "^8.2 || ^8.3 || ^8.4"
+    },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/comptabilite.php
+++ b/comptabilite.php
@@ -1,0 +1,147 @@
+<?php
+require('actions/users/securityAction.php');
+require('actions/db.php');
+require('actions/comptabilite/sessionCaisseHelpers.php');
+
+$columns = [];
+$dateColumn = null;
+$ecartColumn = null;
+$errors = [];
+$results = [];
+$years = [];
+$selectedYear = null;
+
+try {
+    $columns = getSessionCaisseColumns($db);
+    $columnNames = array_column($columns, 'Field');
+    $dateColumn = findSessionCaisseDateColumn($columnNames);
+    $ecartColumn = findSessionCaisseEcartColumn($columnNames);
+
+    if (!$ecartColumn) {
+        $errors[] = "La colonne 'ecart' est introuvable dans la table session_caisse.";
+    }
+
+    if ($dateColumn) {
+        $years = getSessionCaisseYears($db, $dateColumn);
+
+        if (isset($_GET['year'])) {
+            $selectedYear = (int) $_GET['year'];
+        } elseif (!empty($years)) {
+            $selectedYear = (int) $years[0];
+        } else {
+            $selectedYear = (int) date('Y');
+        }
+
+        if ($selectedYear) {
+            $results = getSessionCaisseRowsForYear($db, $dateColumn, $selectedYear);
+        }
+    } else {
+        $errors[] = "Aucune colonne de date n'a été trouvée pour filtrer par année.";
+    }
+} catch (Exception $exception) {
+    $errors[] = 'Impossible de récupérer les sessions de caisse : ' . $exception->getMessage();
+}
+
+$recap = $ecartColumn ? buildEcartRecap($results, $ecartColumn) : [
+    'negative' => 0,
+    'positive' => 0,
+    'count' => 0,
+];
+?>
+
+<!DOCTYPE HTML>
+
+<html lang="fr-FR">
+    <?php include("includes/head.php");?>
+    <body class="corps">
+        <?php
+            $lineheight = "uneligne";
+            $src = 'image/PictoFete.gif';
+            $alt = 'un oiseau qui fait la fête.';
+            $titre = 'Comptabilité';
+            include("includes/header.php");
+            $page = 5;
+            include("includes/nav.php");
+        ?>
+
+        <?php if($_SESSION['admin'] >= 1): ?>
+            <div class="doc">
+                <ul class="doc_ul">
+                    <a class="doc_lien" href="administration.php"><li class="doc_li" id="bleu">Retour à l'administration</li></a>
+                </ul>
+            </div>
+
+            <?php if (!empty($errors)): ?>
+                <div class="alert alert-danger" role="alert" style="margin: 20px;">
+                    <?php foreach ($errors as $error): ?>
+                        <p><?= htmlspecialchars($error) ?></p>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+
+            <?php if (!empty($years) && $dateColumn): ?>
+                <div style="text-align: center;">
+                    <form method="GET" class="formulaire-mois">
+                        <label for="year">Année :</label>
+                        <select name="year" id="year">
+                            <?php foreach ($years as $year): ?>
+                                <option value="<?= (int) $year ?>" <?= (int) $year === $selectedYear ? 'selected' : '' ?>>
+                                    <?= (int) $year ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                        <button type="submit">Afficher</button>
+                    </form>
+                </div>
+            <?php endif; ?>
+
+            <div style="text-align: center; margin: 30px; padding: 20px; background-color: #f9f9f9; border: 2px solid #007BFF; border-radius: 10px;">
+                <h3 style="color: #007BFF;">Récapitulatif annuel</h3>
+                <table class="tableau" style="width: 80%; margin: 0 auto; border-collapse: collapse; background-color: #ffffff;">
+                    <tr class="ligne" style="background-color: #007BFF; color: #ffffff;">
+                        <th class="cellule_tete" style="padding: 10px; border: 1px solid #007BFF;">Total des écarts négatifs</th>
+                        <th class="cellule_tete" style="padding: 10px; border: 1px solid #007BFF;">Total des écarts positifs</th>
+                        <th class="cellule_tete" style="padding: 10px; border: 1px solid #007BFF;">Nombre de sessions</th>
+                    </tr>
+                    <tr class="ligne" style="text-align: center;">
+                        <td class="colonne" style="padding: 10px; border: 1px solid #007BFF;"><?= formatEcartValue($recap['negative']) ?></td>
+                        <td class="colonne" style="padding: 10px; border: 1px solid #007BFF;"><?= formatEcartValue($recap['positive']) ?></td>
+                        <td class="colonne" style="padding: 10px; border: 1px solid #007BFF;"><?= $recap['count'] ?></td>
+                    </tr>
+                </table>
+            </div>
+
+            <?php if ($ecartColumn && $dateColumn && $selectedYear): ?>
+                <div style="text-align: center; margin-bottom: 20px;">
+                    <a class="stdbouton" href="actions/comptabilite/generateComptabilitePdf.php?year=<?= (int) $selectedYear ?>">
+                        Télécharger le PDF des sessions avec écarts
+                    </a>
+                </div>
+            <?php endif; ?>
+
+            <?php if (!empty($results) && !empty($columns)): ?>
+                <table class="tableau">
+                    <tr class="ligne">
+                        <?php foreach ($columns as $column): ?>
+                            <th class="cellule_tete"><?= htmlspecialchars(ucwords(str_replace('_', ' ', $column['Field']))) ?></th>
+                        <?php endforeach; ?>
+                    </tr>
+                    <?php foreach ($results as $row): ?>
+                        <tr class="ligne">
+                            <?php foreach ($columns as $column): ?>
+                                <?php $value = $row[$column['Field']] ?? ''; ?>
+                                <td class="colonne"><?= htmlspecialchars((string) $value) ?></td>
+                            <?php endforeach; ?>
+                        </tr>
+                    <?php endforeach; ?>
+                </table>
+            <?php else: ?>
+                <p style="text-align: center;">Aucune session de caisse trouvée pour cette année.</p>
+            <?php endif; ?>
+        <?php else: ?>
+            <p>Vous n'êtes pas administrateur, veuillez contacter le webmaster svp.</p>
+        <?php endif; ?>
+
+        <?php include('includes/footer.php'); ?>
+    </body>
+</html>

--- a/includes/nav.php
+++ b/includes/nav.php
@@ -9,6 +9,9 @@ $mode_dev = false; // Toggle ici
         <li class="navforum_li <?php echo ($page == 2) ? 'vert' : 'bleu'; ?>"><a class="lien_li" href="accueil_vente.php">Vente</a></li>
         <li class="navforum_li <?php echo ($page == 3) ? 'vert' : 'bleu'; ?>"><a class="lien_li" href="bilan.php">Bilans</a></li>
         <li class="navforum_li <?php echo ($page == 4) ? 'vert' : 'bleu'; ?>"><a class="lien_li" href="reparation.php">Reparation</a></li>
+        <?php if (isset($_SESSION['admin']) && $_SESSION['admin'] >= 1): ?>
+            <li class="navforum_li <?php echo ($page == 5) ? 'vert' : 'bleu'; ?>"><a class="lien_li" href="administration.php">Administration</a></li>
+        <?php endif; ?>
         
         <?php if ($mode_dev): ?>
             <li class="navforum_li orange"><a class="lien_li" href="test_debug.php">🧪 Tests</a></li>


### PR DESCRIPTION
### Motivation
- Provide an admin-only PDF export of cash-register sessions that includes only sessions with non-zero `ecart`, with totals and bookkeeping-friendly information for annual accounting. 
- Centralize and simplify detection of the date and `ecart` columns and recap logic to avoid duplicated code across pages. 
- Surface an easy UI entry point so administrators can download the generated yearly PDF from the accounting page.

### Description
- Introduce a helper module `actions/comptabilite/sessionCaisseHelpers.php` exposing `getSessionCaisseColumns()`, `findSessionCaisseDateColumn()`, `findSessionCaisseEcartColumn()`, `getSessionCaisseYears()`, `getSessionCaisseRowsForYear()`, `buildEcartRecap()` and `formatEcartValue()` to centralize schema inspection and recap computation. 
- Add `actions/comptabilite/generateComptabilitePdf.php` which uses the FPDF library to generate a downloadable PDF containing: yearly header, recap totals (total negative, total positive, net), counts, a detail table of sessions filtered to only those with `ecart != 0`, and signature blocks for the treasurer and president; it validates admin access and required columns before generating the file. 
- Update `comptabilite.php` to use the new helpers for column detection and recap calculation and to show a `Télécharger le PDF des sessions avec écarts` link when an admin and a year are selected. 
- Add a minimal `administration.php` landing page and expose the Administration link in `includes/nav.php` only when `$_SESSION['admin'] >= 1`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980fb67f5808327984e1204d920be8d)