### PR TITLE
Ajouter des libellés user-friendly pour les colonnes de session_caisse

### DIFF
--- a/actions/comptabilite/generateComptabilitePdf.php
+++ b/actions/comptabilite/generateComptabilitePdf.php
@@ -302,17 +302,14 @@ foreach (['fond_initial', 'montant_reel', 'montant_reel_carte', 'montant_reel_ch
     }
 }
 // Meta
-foreach (['commentaire', 'cashiers', 'poste', 'issecondaire'] as $metaColumn) {
+foreach (['commentaire', 'caissiers', 'cashiers', 'poste', 'issecondaire'] as $metaColumn) {
     if (in_array($metaColumn, $columnNames, true)) {
         $displayColumns[] = $metaColumn;
     }
 }
 
 // Labels
-$columnLabels = [];
-foreach ($displayColumns as $columnName) {
-    $columnLabels[] = ucwords(str_replace('_', ' ', $columnName));
-}
+$columnLabels = getSessionCaisseColumnLabels($displayColumns);
 
 // Largeurs “de base” (avant scaling) : adaptées à tes types de colonnes
 $baseWidthMap = [

--- a/actions/comptabilite/sessionCaisseHelpers.php
+++ b/actions/comptabilite/sessionCaisseHelpers.php
@@ -80,3 +80,45 @@ function formatEcartValue(float $value): string
 {
     return number_format($value/100, 2, ',', ' ') . ' €';
 }
+
+function getSessionCaisseColumnLabel(string $columnName): string
+{
+    $labelMap = [
+        'id_session' => 'ID session',
+        'utilisateur_ouverture' => 'Utilisateur ouverture',
+        'responsable_ouverture' => 'Responsable ouverture',
+        'fond_initial' => 'Fond initial',
+        'utilisateur_fermeture' => 'Utilisateur fermeture',
+        'responsable_fermeture' => 'Responsable fermeture',
+        'montant_reel' => 'Montant réel',
+        'commentaire' => 'Commentaire',
+        'ecart' => 'Écart',
+        'caissiers' => 'Caissiers',
+        'cashiers' => 'Caissiers',
+        'montant_reel_carte' => 'Montant réel carte',
+        'montant_reel_cheque' => 'Montant réel chèque',
+        'montant_reel_virement' => 'Montant réel virement',
+        'issecondaire' => 'Secondaire',
+        'poste' => 'Poste',
+        'opened_at_utc' => 'Ouverture (UTC)',
+        'closed_at_utc' => 'Fermeture (UTC)',
+        'closed_at' => 'Fermeture',
+        'uuid_caisse_principale_si_secondaire' => 'UUID caisse principale (si secondaire)',
+    ];
+
+    if (array_key_exists($columnName, $labelMap)) {
+        return $labelMap[$columnName];
+    }
+
+    return ucwords(str_replace('_', ' ', $columnName));
+}
+
+function getSessionCaisseColumnLabels(array $columns): array
+{
+    $labels = [];
+    foreach ($columns as $columnName) {
+        $labels[] = getSessionCaisseColumnLabel($columnName);
+    }
+
+    return $labels;
+}

--- a/comptabilite.php
+++ b/comptabilite.php
@@ -123,7 +123,7 @@ $recap = $ecartColumn ? buildEcartRecap($results, $ecartColumn) : [
                 <table class="tableau">
                     <tr class="ligne">
                         <?php foreach ($columns as $column): ?>
-                            <th class="cellule_tete"><?= htmlspecialchars(ucwords(str_replace('_', ' ', $column['Field']))) ?></th>
+                            <th class="cellule_tete"><?= htmlspecialchars(getSessionCaisseColumnLabel($column['Field'])) ?></th>
                         <?php endforeach; ?>
                     </tr>
                     <?php foreach ($results as $row): ?>


### PR DESCRIPTION
### Motivation
- Rendre les en-têtes de colonnes plus lisibles pour l'utilisateur sur la page `comptabilite` et dans le PDF généré à partir de la table `session_caisse`.
- Centraliser les libellés pour éviter la duplication et faciliter les personnalisations futures.

### Description
- Ajout de `getSessionCaisseColumnLabel()` et `getSessionCaisseColumnLabels()` dans `actions/comptabilite/sessionCaisseHelpers.php` pour fournir un mapping centralisé nom de colonne → libellé lisible.
- Remplacement du rendu brut `ucwords(str_replace('_',' ',...))` dans `comptabilite.php` par `getSessionCaisseColumnLabel()` pour les en-têtes du tableau affiché à l'écran.
- Utilisation de `getSessionCaisseColumnLabels()` dans `actions/comptabilite/generateComptabilitePdf.php` pour afficher les mêmes libellés dans l'en-tête du tableau PDF et ajout de la colonne `caissiers` à la sélection des colonnes méta.
- Le mapping inclut les colonnes courantes (`fond_initial`, `montant_reel`, `ecart`, `opened_at_utc`, `closed_at_utc`, etc.) et une valeur par défaut formatée si la colonne n'est pas mappée.

### Testing
- Aucun test automatisé exécuté.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698458a1f6e48327839fee2c09dfb0ea)