### PR TITLE
Ajuster le montant réel espèces en soustrayant le fond initial

### DIFF
--- a/comptabilite.php
+++ b/comptabilite.php
@@ -8,6 +8,7 @@ $columns = [];
 $dateColumn = null;
 $ecartColumn = null;
 $montantReelColumn = null;
+$fondInitialColumn = null;
 $montantReelCarteColumn = null;
 $montantReelChequeColumn = null;
 $montantReelVirementColumn = null;
@@ -24,6 +25,7 @@ try {
     $dateColumn = findSessionCaisseDateColumn($columnNames);
     $ecartColumn = findSessionCaisseEcartColumn($columnNames);
     $montantReelColumn = findSessionCaisseMontantReelColumn($columnNames);
+    $fondInitialColumn = in_array('fond_initial', $columnNames, true) ? 'fond_initial' : null;
     $montantReelCarteColumn = in_array('montant_reel_carte', $columnNames, true) ? 'montant_reel_carte' : null;
     $montantReelChequeColumn = in_array('montant_reel_cheque', $columnNames, true) ? 'montant_reel_cheque' : null;
     $montantReelVirementColumn = in_array('montant_reel_virement', $columnNames, true) ? 'montant_reel_virement' : null;
@@ -114,8 +116,11 @@ if ($selectedYear) {
             ];
         }
 
+        $montantReelEspece = (float) ($row[$montantReelColumn] ?? 0);
+        $fondInitial = $fondInitialColumn ? (float) ($row[$fondInitialColumn] ?? 0) : 0;
+
         $combinedRows[$dateKey]['sessions'][] = [
-            'espece' => $row[$montantReelColumn] ?? null,
+            'espece' => $montantReelEspece - $fondInitial,
             'carte' => $montantReelCarteColumn ? ($row[$montantReelCarteColumn] ?? null) : null,
             'cheque' => $montantReelChequeColumn ? ($row[$montantReelChequeColumn] ?? null) : null,
             'virement' => $montantReelVirementColumn ? ($row[$montantReelVirementColumn] ?? null) : null,


### PR DESCRIPTION
### Motivation
- Dans l'affichage comptabilité, la colonne `fond_initial` existe et doit être déduite du `montant_reel` pour l'affichage des espèces afin de refléter le montant réellement comptabilisé.

### Description
- Détecte la présence de la colonne `fond_initial` en initialisant `$fondInitialColumn` depuis la liste des colonnes de `session_caisse`.
- Calcule `$montantReelEspece = (float) ($row[$montantReelColumn] ?? 0)` et `$fondInitial` (fallback `0` si la colonne est absente) pour chaque session.
- Remplace la valeur affichée des espèces dans les sessions par `montant_reel - fond_initial` lors de la construction de `$combinedRows`.
- Modifications réalisées dans le fichier `comptabilite.php` sans altérer le reste du rendu ni le fallback quand la colonne est manquante.

### Testing
- Vérification de la syntaxe PHP via `php -l comptabilite.php` : succès.
- Lancement d'un serveur de développement PHP (`php -S 0.0.0.0:8000`) et capture de la page `comptabilite.php` avec un script Playwright : navigation et screenshot réussis.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985d25851d0832796a1d3460e6dc0d6)