### PR TITLE
Ajoute l'onglet et la page «Charge de travail» avec helper de calcul

### DIFF
--- a/actions/comptabilite/bilanHelpers.php
+++ b/actions/comptabilite/bilanHelpers.php
@@ -21,3 +21,51 @@ function getBilanTotalsForYear(PDO $db, int $year): array
 
     return $statement->fetchAll(PDO::FETCH_ASSOC);
 }
+
+function getChargeTravailStatsForYear(PDO $db, int $year): array
+{
+    $periodStart = sprintf('%d-01-01 00:00:00', $year);
+    $periodEnd = sprintf('%d-12-31 23:59:59', $year);
+
+    $eventDaysSql = "SELECT
+                        COUNT(DISTINCT DATE(start)) AS total_activity_days,
+                        COUNT(DISTINCT CASE WHEN DAYOFWEEK(start) <> 3 THEN DATE(start) END) AS total_sales_days,
+                        COUNT(DISTINCT CASE WHEN DAYOFWEEK(start) <> 3 AND MOD(WEEKOFYEAR(start), 2) <> 0 THEN DATE(start) END) AS total_collection_days
+                    FROM events
+                    WHERE cat_creneau = 0
+                      AND start BETWEEN :periodStart AND :periodEnd";
+
+    $eventDaysStmt = $db->prepare($eventDaysSql);
+    $eventDaysStmt->execute([
+        'periodStart' => $periodStart,
+        'periodEnd' => $periodEnd,
+    ]);
+    $eventDays = $eventDaysStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+
+    $hoursSql = "SELECT
+                    COALESCE(SUM(CASE WHEN employes.uuid_user IS NULL THEN TIMESTAMPDIFF(MINUTE, events.start, events.end) END), 0) DIV 60 AS benevolat_hours,
+                    COALESCE(SUM(CASE WHEN employes.uuid_user IS NOT NULL THEN TIMESTAMPDIFF(MINUTE, events.start, events.end) END), 0) DIV 60 AS employee_hours
+                 FROM events
+                 INNER JOIN inscription_creneau ON inscription_creneau.id_event = events.id
+                 INNER JOIN users ON users.uuid_user = inscription_creneau.id_user
+                 LEFT JOIN employes ON employes.uuid_user = users.uuid_user
+                 WHERE events.start >= :periodStart
+                   AND events.end <= :periodEnd";
+
+    $hoursStmt = $db->prepare($hoursSql);
+    $hoursStmt->execute([
+        'periodStart' => $periodStart,
+        'periodEnd' => $periodEnd,
+    ]);
+    $hours = $hoursStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+
+    return [
+        'period_start' => $periodStart,
+        'period_end' => $periodEnd,
+        'total_activity_days' => (int) ($eventDays['total_activity_days'] ?? 0),
+        'total_sales_days' => (int) ($eventDays['total_sales_days'] ?? 0),
+        'total_collection_days' => (int) ($eventDays['total_collection_days'] ?? 0),
+        'benevolat_hours' => (int) ($hours['benevolat_hours'] ?? 0),
+        'employee_hours' => (int) ($hours['employee_hours'] ?? 0),
+    ];
+}

--- a/actions/comptabilite/bilanHelpers.php
+++ b/actions/comptabilite/bilanHelpers.php
@@ -24,7 +24,7 @@ function getBilanTotalsForYear(PDO $db, int $year): array
 
 function getEmployeeContractHoursForPeriod(PDO $db, DateTimeImmutable $periodStart, DateTimeImmutable $periodEnd): int
 {
-    $contractsSql = "SELECT uuid_user, date_debut, date_fin, status, heures_mensuelles
+    $contractsSql = "SELECT uuid_user, date_debut, date_fin, status, heures_hebdomadaires
                      FROM employes
                      WHERE date_debut <= :periodEndDate
                        AND date_fin >= :periodStartDate
@@ -49,26 +49,13 @@ function getEmployeeContractHoursForPeriod(PDO $db, DateTimeImmutable $periodSta
             continue;
         }
 
-        $monthlyHours = (float) ($contract['heures_mensuelles'] ?? 0);
-        if ($monthlyHours <= 0) {
+        $weeklyHours = (float) ($contract['heures_hebdomadaires'] ?? 0);
+        if ($weeklyHours <= 0) {
             continue;
         }
 
-        $cursor = $effectiveStart->modify('first day of this month 00:00:00');
-        while ($cursor <= $effectiveEnd) {
-            $monthStart = $cursor;
-            $monthEnd = $cursor->modify('last day of this month 23:59:59');
-            $sliceStart = $monthStart < $effectiveStart ? $effectiveStart : $monthStart;
-            $sliceEnd = $monthEnd > $effectiveEnd ? $effectiveEnd : $monthEnd;
-
-            if ($sliceStart <= $sliceEnd) {
-                $daysInMonth = (int) $monthStart->format('t');
-                $coveredDays = (int) $sliceEnd->format('j') - (int) $sliceStart->format('j') + 1;
-                $totalHours += $monthlyHours * ($coveredDays / $daysInMonth);
-            }
-
-            $cursor = $cursor->modify('first day of next month 00:00:00');
-        }
+        $coveredDays = (int) $effectiveEnd->diff($effectiveStart)->format('%a') + 1;
+        $totalHours += $weeklyHours * ($coveredDays / 7);
     }
 
     return (int) round($totalHours);

--- a/actions/comptabilite/bilanHelpers.php
+++ b/actions/comptabilite/bilanHelpers.php
@@ -22,27 +22,53 @@ function getBilanTotalsForYear(PDO $db, int $year): array
     return $statement->fetchAll(PDO::FETCH_ASSOC);
 }
 
-function getEmployeeContractHoursForPeriod(int $year, DateTimeImmutable $periodEnd, int $employeeCount): int
+function getEmployeeContractHoursForPeriod(PDO $db, DateTimeImmutable $periodStart, DateTimeImmutable $periodEnd): int
 {
-    if ($employeeCount <= 0) {
-        return 0;
-    }
+    $contractsSql = "SELECT uuid_user, date_debut, date_fin, status, heures_mensuelles
+                     FROM employes
+                     WHERE date_debut <= :periodEndDate
+                       AND date_fin >= :periodStartDate
+                     ORDER BY uuid_user, date_debut";
 
-    $periodStart = new DateTimeImmutable(sprintf('%d-01-01 00:00:00', $year));
-    $cursor = $periodStart->modify('first day of this month');
+    $contractsStmt = $db->prepare($contractsSql);
+    $contractsStmt->execute([
+        'periodStartDate' => $periodStart->format('Y-m-d'),
+        'periodEndDate' => $periodEnd->format('Y-m-d'),
+    ]);
+
+    $contracts = $contractsStmt->fetchAll(PDO::FETCH_ASSOC);
     $totalHours = 0.0;
 
-    while ($cursor <= $periodEnd) {
-        $monthStart = $cursor;
-        $monthEnd = $cursor->modify('last day of this month 23:59:59');
-        $effectiveEnd = $monthEnd > $periodEnd ? $periodEnd : $monthEnd;
+    foreach ($contracts as $contract) {
+        $contractStart = new DateTimeImmutable(($contract['date_debut'] ?? $periodStart->format('Y-m-d')) . ' 00:00:00');
+        $contractEnd = new DateTimeImmutable(($contract['date_fin'] ?? $periodEnd->format('Y-m-d')) . ' 23:59:59');
+        $effectiveStart = $contractStart > $periodStart ? $contractStart : $periodStart;
+        $effectiveEnd = $contractEnd < $periodEnd ? $contractEnd : $periodEnd;
 
-        $daysInMonth = (int) $monthStart->format('t');
-        $coveredDays = (int) $effectiveEnd->format('j');
-        $monthlyHours = ($year === 2025 && (int) $monthStart->format('n') <= 5) ? (25 * 52 / 12) : 130;
+        if ($effectiveStart > $effectiveEnd) {
+            continue;
+        }
 
-        $totalHours += ($monthlyHours * ($coveredDays / $daysInMonth)) * $employeeCount;
-        $cursor = $cursor->modify('first day of next month');
+        $monthlyHours = (float) ($contract['heures_mensuelles'] ?? 0);
+        if ($monthlyHours <= 0) {
+            continue;
+        }
+
+        $cursor = $effectiveStart->modify('first day of this month 00:00:00');
+        while ($cursor <= $effectiveEnd) {
+            $monthStart = $cursor;
+            $monthEnd = $cursor->modify('last day of this month 23:59:59');
+            $sliceStart = $monthStart < $effectiveStart ? $effectiveStart : $monthStart;
+            $sliceEnd = $monthEnd > $effectiveEnd ? $effectiveEnd : $monthEnd;
+
+            if ($sliceStart <= $sliceEnd) {
+                $daysInMonth = (int) $monthStart->format('t');
+                $coveredDays = (int) $sliceEnd->format('j') - (int) $sliceStart->format('j') + 1;
+                $totalHours += $monthlyHours * ($coveredDays / $daysInMonth);
+            }
+
+            $cursor = $cursor->modify('first day of next month 00:00:00');
+        }
     }
 
     return (int) round($totalHours);
@@ -55,6 +81,7 @@ function getChargeTravailStatsForYear(PDO $db, int $year): array
     $periodEnd = $year < $currentYear
         ? sprintf('%d-12-31 23:59:59', $year)
         : date('Y-m-d 23:59:59');
+    $periodStartDate = new DateTimeImmutable($periodStart);
     $periodEndDate = new DateTimeImmutable($periodEnd);
 
     $eventDaysSql = "SELECT
@@ -89,9 +116,7 @@ function getChargeTravailStatsForYear(PDO $db, int $year): array
     ]);
     $benevolatHours = (int) (($benevolatStmt->fetch(PDO::FETCH_ASSOC) ?: [])['benevolat_hours'] ?? 0);
 
-    $employeeCountStmt = $db->query('SELECT COUNT(*) AS total_employees FROM employes');
-    $employeeCount = (int) (($employeeCountStmt->fetch(PDO::FETCH_ASSOC) ?: [])['total_employees'] ?? 0);
-    $employeeHours = getEmployeeContractHoursForPeriod($year, $periodEndDate, $employeeCount);
+    $employeeHours = getEmployeeContractHoursForPeriod($db, $periodStartDate, $periodEndDate);
 
     return [
         'period_start' => $periodStart,

--- a/actions/comptabilite/bilanHelpers.php
+++ b/actions/comptabilite/bilanHelpers.php
@@ -27,7 +27,7 @@ function getEmployeeContractHoursForPeriod(PDO $db, DateTimeImmutable $periodSta
     $contractsSql = "SELECT uuid_user, date_debut, date_fin, status, heures_hebdomadaires
                      FROM employes
                      WHERE date_debut <= :periodEndDate
-                       AND date_fin >= :periodStartDate
+                       AND (date_fin = '0000-00-00' OR date_fin >= :periodStartDate)
                      ORDER BY uuid_user, date_debut";
 
     $contractsStmt = $db->prepare($contractsSql);
@@ -41,7 +41,10 @@ function getEmployeeContractHoursForPeriod(PDO $db, DateTimeImmutable $periodSta
 
     foreach ($contracts as $contract) {
         $contractStart = new DateTimeImmutable(($contract['date_debut'] ?? $periodStart->format('Y-m-d')) . ' 00:00:00');
-        $contractEnd = new DateTimeImmutable(($contract['date_fin'] ?? $periodEnd->format('Y-m-d')) . ' 23:59:59');
+        $rawContractEnd = $contract['date_fin'] ?? $periodEnd->format('Y-m-d');
+        $contractEnd = $rawContractEnd === '0000-00-00'
+            ? $periodEnd
+            : new DateTimeImmutable($rawContractEnd . ' 23:59:59');
         $effectiveStart = $contractStart > $periodStart ? $contractStart : $periodStart;
         $effectiveEnd = $contractEnd < $periodEnd ? $contractEnd : $periodEnd;
 

--- a/actions/comptabilite/bilanHelpers.php
+++ b/actions/comptabilite/bilanHelpers.php
@@ -24,8 +24,11 @@ function getBilanTotalsForYear(PDO $db, int $year): array
 
 function getChargeTravailStatsForYear(PDO $db, int $year): array
 {
+    $currentYear = (int) date('Y');
     $periodStart = sprintf('%d-01-01 00:00:00', $year);
-    $periodEnd = sprintf('%d-12-31 23:59:59', $year);
+    $periodEnd = $year < $currentYear
+        ? sprintf('%d-12-31 23:59:59', $year)
+        : date('Y-m-d 23:59:59');
 
     $eventDaysSql = "SELECT
                         COUNT(DISTINCT DATE(start)) AS total_activity_days,

--- a/actions/comptabilite/bilanHelpers.php
+++ b/actions/comptabilite/bilanHelpers.php
@@ -22,7 +22,7 @@ function getBilanTotalsForYear(PDO $db, int $year): array
     return $statement->fetchAll(PDO::FETCH_ASSOC);
 }
 
-function getEmployeeContractHoursForPeriod(PDO $db, DateTimeImmutable $periodStart, DateTimeImmutable $periodEnd): int
+function getEmployeeContractHoursForPeriod(PDO $db, DateTimeImmutable $periodStart, DateTimeImmutable $periodEnd): array
 {
     $contractsSql = "SELECT uuid_user, date_debut, date_fin, status, heures_hebdomadaires
                      FROM employes
@@ -37,7 +37,10 @@ function getEmployeeContractHoursForPeriod(PDO $db, DateTimeImmutable $periodSta
     ]);
 
     $contracts = $contractsStmt->fetchAll(PDO::FETCH_ASSOC);
-    $totalHours = 0.0;
+    $hoursByStatus = [
+        1 => 0.0,
+        2 => 0.0,
+    ];
 
     foreach ($contracts as $contract) {
         $contractStart = new DateTimeImmutable(($contract['date_debut'] ?? $periodStart->format('Y-m-d')) . ' 00:00:00');
@@ -52,16 +55,25 @@ function getEmployeeContractHoursForPeriod(PDO $db, DateTimeImmutable $periodSta
             continue;
         }
 
+        $status = (int) ($contract['status'] ?? 0);
+        if (!array_key_exists($status, $hoursByStatus)) {
+            continue;
+        }
+
         $weeklyHours = (float) ($contract['heures_hebdomadaires'] ?? 0);
         if ($weeklyHours <= 0) {
             continue;
         }
 
         $coveredDays = (int) $effectiveEnd->diff($effectiveStart)->format('%a') + 1;
-        $totalHours += $weeklyHours * ($coveredDays / 7);
+        $hoursByStatus[$status] += $weeklyHours * ($coveredDays / 7);
     }
 
-    return (int) round($totalHours);
+    return [
+        'total' => (int) round($hoursByStatus[1] + $hoursByStatus[2]),
+        'coordinatrice' => (int) round($hoursByStatus[1]),
+        'agent_entretien' => (int) round($hoursByStatus[2]),
+    ];
 }
 
 function getChargeTravailStatsForYear(PDO $db, int $year): array
@@ -115,6 +127,8 @@ function getChargeTravailStatsForYear(PDO $db, int $year): array
         'total_sales_days' => (int) ($eventDays['total_sales_days'] ?? 0),
         'total_collection_days' => (int) ($eventDays['total_collection_days'] ?? 0),
         'benevolat_hours' => $benevolatHours,
-        'employee_hours' => $employeeHours,
+        'employee_hours' => $employeeHours['total'],
+        'employee_hours_coordinatrice' => $employeeHours['coordinatrice'],
+        'employee_hours_agent_entretien' => $employeeHours['agent_entretien'],
     ];
 }

--- a/actions/comptabilite/bilanHelpers.php
+++ b/actions/comptabilite/bilanHelpers.php
@@ -22,6 +22,32 @@ function getBilanTotalsForYear(PDO $db, int $year): array
     return $statement->fetchAll(PDO::FETCH_ASSOC);
 }
 
+function getEmployeeContractHoursForPeriod(int $year, DateTimeImmutable $periodEnd, int $employeeCount): int
+{
+    if ($employeeCount <= 0) {
+        return 0;
+    }
+
+    $periodStart = new DateTimeImmutable(sprintf('%d-01-01 00:00:00', $year));
+    $cursor = $periodStart->modify('first day of this month');
+    $totalHours = 0.0;
+
+    while ($cursor <= $periodEnd) {
+        $monthStart = $cursor;
+        $monthEnd = $cursor->modify('last day of this month 23:59:59');
+        $effectiveEnd = $monthEnd > $periodEnd ? $periodEnd : $monthEnd;
+
+        $daysInMonth = (int) $monthStart->format('t');
+        $coveredDays = (int) $effectiveEnd->format('j');
+        $monthlyHours = ($year === 2025 && (int) $monthStart->format('n') <= 5) ? (25 * 52 / 12) : 130;
+
+        $totalHours += ($monthlyHours * ($coveredDays / $daysInMonth)) * $employeeCount;
+        $cursor = $cursor->modify('first day of next month');
+    }
+
+    return (int) round($totalHours);
+}
+
 function getChargeTravailStatsForYear(PDO $db, int $year): array
 {
     $currentYear = (int) date('Y');
@@ -29,6 +55,7 @@ function getChargeTravailStatsForYear(PDO $db, int $year): array
     $periodEnd = $year < $currentYear
         ? sprintf('%d-12-31 23:59:59', $year)
         : date('Y-m-d 23:59:59');
+    $periodEndDate = new DateTimeImmutable($periodEnd);
 
     $eventDaysSql = "SELECT
                         COUNT(DISTINCT DATE(start)) AS total_activity_days,
@@ -45,22 +72,26 @@ function getChargeTravailStatsForYear(PDO $db, int $year): array
     ]);
     $eventDays = $eventDaysStmt->fetch(PDO::FETCH_ASSOC) ?: [];
 
-    $hoursSql = "SELECT
-                    COALESCE(SUM(CASE WHEN employes.uuid_user IS NULL THEN TIMESTAMPDIFF(MINUTE, events.start, events.end) END), 0) DIV 60 AS benevolat_hours,
-                    COALESCE(SUM(CASE WHEN employes.uuid_user IS NOT NULL THEN TIMESTAMPDIFF(MINUTE, events.start, events.end) END), 0) DIV 60 AS employee_hours
-                 FROM events
-                 INNER JOIN inscription_creneau ON inscription_creneau.id_event = events.id
-                 INNER JOIN users ON users.uuid_user = inscription_creneau.id_user
-                 LEFT JOIN employes ON employes.uuid_user = users.uuid_user
-                 WHERE events.start >= :periodStart
-                   AND events.end <= :periodEnd";
+    $benevolatSql = "SELECT
+                        COALESCE(SUM(TIMESTAMPDIFF(MINUTE, events.start, events.end)), 0) DIV 60 AS benevolat_hours
+                     FROM events
+                     INNER JOIN inscription_creneau ON inscription_creneau.id_event = events.id
+                     INNER JOIN users ON users.uuid_user = inscription_creneau.id_user
+                     LEFT JOIN employes ON employes.uuid_user = users.uuid_user
+                     WHERE employes.uuid_user IS NULL
+                       AND events.start >= :periodStart
+                       AND events.end <= :periodEnd";
 
-    $hoursStmt = $db->prepare($hoursSql);
-    $hoursStmt->execute([
+    $benevolatStmt = $db->prepare($benevolatSql);
+    $benevolatStmt->execute([
         'periodStart' => $periodStart,
         'periodEnd' => $periodEnd,
     ]);
-    $hours = $hoursStmt->fetch(PDO::FETCH_ASSOC) ?: [];
+    $benevolatHours = (int) (($benevolatStmt->fetch(PDO::FETCH_ASSOC) ?: [])['benevolat_hours'] ?? 0);
+
+    $employeeCountStmt = $db->query('SELECT COUNT(*) AS total_employees FROM employes');
+    $employeeCount = (int) (($employeeCountStmt->fetch(PDO::FETCH_ASSOC) ?: [])['total_employees'] ?? 0);
+    $employeeHours = getEmployeeContractHoursForPeriod($year, $periodEndDate, $employeeCount);
 
     return [
         'period_start' => $periodStart,
@@ -68,7 +99,7 @@ function getChargeTravailStatsForYear(PDO $db, int $year): array
         'total_activity_days' => (int) ($eventDays['total_activity_days'] ?? 0),
         'total_sales_days' => (int) ($eventDays['total_sales_days'] ?? 0),
         'total_collection_days' => (int) ($eventDays['total_collection_days'] ?? 0),
-        'benevolat_hours' => (int) ($hours['benevolat_hours'] ?? 0),
-        'employee_hours' => (int) ($hours['employee_hours'] ?? 0),
+        'benevolat_hours' => $benevolatHours,
+        'employee_hours' => $employeeHours,
     ];
 }

--- a/bilan.php
+++ b/bilan.php
@@ -39,6 +39,7 @@ $annee = date('Y');
                 <a class="doc_lien" href="prixoeuvre.php?annee=<?php echo $annee ?>"><li class="doc_li" id="bleu">Oeuvres</li></a>
                 <a class="doc_lien" href="BilanObjetsCollectes.php"><li class="doc_li" id="bleu">Objets Collectés</li></a>
                 <a class="doc_lien" href="BilanObjetsVendus.php"><li class="doc_li" id="bleu">Objets Vendus</li></a>
+                <a class="doc_lien" href="chargeTravail.php?annee=<?php echo $annee ?>"><li class="doc_li" id="bleu">Charge de travail</li></a>
                 <a class="doc_lien" href="bilanDechetterie.php"><li class="doc_li" id="bleu">Bilan dechetterie</li></a>
                 <a class="doc_lien" href="telechargementDB.php"><li class="doc_li" id="bleu">Télécharger la DB 2024</li></a>
             </ul>

--- a/chargeTravail.php
+++ b/chargeTravail.php
@@ -1,0 +1,55 @@
+<?php
+require('actions/users/securityAction.php');
+require('actions/db.php');
+require('actions/comptabilite/bilanHelpers.php');
+
+$annee = isset($_GET['annee']) ? (int) $_GET['annee'] : (int) date('Y');
+if ($annee < 2000 || $annee > 2100) {
+    $annee = (int) date('Y');
+}
+
+$chargeTravail = getChargeTravailStatsForYear($db, $annee);
+?>
+
+<!DOCTYPE HTML>
+<html lang="fr-FR">
+    <?php include('includes/head.php'); ?>
+    <body class="corps">
+        <?php
+            $lineheight = 'uneligne';
+            $src = 'image/PictoFete.gif';
+            $alt = 'un oiseau qui fait la fête.';
+            $titre = 'Charge de travail';
+            include('includes/header.php');
+            $page = 3;
+            include('includes/nav.php');
+        ?>
+
+        <?php if ($_SESSION['admin'] >= 1) { ?>
+            <div class="doc">
+                <ul class="doc_ul">
+                    <a class="doc_lien" href="bilan.php"><li class="doc_li" id="bleu">Retour aux bilans</li></a>
+                </ul>
+            </div>
+
+            <div class="container">
+                <div class="resume">
+                    <div class="cadre">
+                        <h2>Charge de travail <?= htmlspecialchars((string) $annee, ENT_QUOTES, 'UTF-8') ?></h2>
+                        <p><strong>Période :</strong> du <?= date('d/m/Y', strtotime($chargeTravail['period_start'])) ?> au <?= date('d/m/Y', strtotime($chargeTravail['period_end'])) ?></p>
+                        <p><strong>Jours totaux d'activité :</strong> <?= $chargeTravail['total_activity_days'] ?></p>
+                        <p><strong>Jours de vente :</strong> <?= $chargeTravail['total_sales_days'] ?></p>
+                        <p><strong>Jours de collecte :</strong> <?= $chargeTravail['total_collection_days'] ?></p>
+                        <p><strong>Heures de bénévolat :</strong> <?= $chargeTravail['benevolat_hours'] ?> h</p>
+                        <p><strong>Heures des salariés :</strong> <?= $chargeTravail['employee_hours'] ?> h</p>
+                    </div>
+                </div>
+            </div>
+        <?php } else {
+            echo 'Vous n\'êtes pas administrateur, veuillez contacter le webmaster svp';
+        }
+
+        include('includes/footer.php');
+        ?>
+    </body>
+</html>

--- a/chargeTravail.php
+++ b/chargeTravail.php
@@ -8,6 +8,18 @@ if ($annee < 2000 || $annee > 2100) {
     $annee = (int) date('Y');
 }
 
+$yearsStmt = $db->query("SELECT DISTINCT YEAR(start) AS annee FROM events WHERE start IS NOT NULL ORDER BY annee DESC");
+$availableYears = array_values(array_filter(
+    array_map(static fn($row) => isset($row['annee']) ? (int) $row['annee'] : null, $yearsStmt->fetchAll(PDO::FETCH_ASSOC)),
+    static fn($year) => $year !== null && $year >= 2000 && $year <= 2100
+));
+
+if ($availableYears === []) {
+    $availableYears = [$annee];
+} elseif (!in_array($annee, $availableYears, true)) {
+    $annee = $availableYears[0];
+}
+
 $chargeTravail = getChargeTravailStatsForYear($db, $annee);
 ?>
 
@@ -27,9 +39,14 @@ $chargeTravail = getChargeTravailStatsForYear($db, $annee);
 
         <?php if ($_SESSION['admin'] >= 1) { ?>
             <div class="doc">
-                <ul class="doc_ul">
-                    <a class="doc_lien" href="bilan.php"><li class="doc_li" id="bleu">Retour aux bilans</li></a>
-                </ul>
+                <form method="get" class="jeuchamp" id="filtre-annee-form" style="display:flex;gap:.75rem;align-items:center;justify-content:center;flex-wrap:wrap;">
+                    <label for="annee" class="champ">Année :</label>
+                    <select id="annee" name="annee" class="input" onchange="this.form.submit()">
+                        <?php foreach ($availableYears as $yearOption) { ?>
+                            <option value="<?= $yearOption ?>" <?= $yearOption === $annee ? 'selected' : '' ?>><?= $yearOption ?></option>
+                        <?php } ?>
+                    </select>
+                </form>
             </div>
 
             <div class="container">

--- a/chargeTravail.php
+++ b/chargeTravail.php
@@ -58,7 +58,9 @@ $chargeTravail = getChargeTravailStatsForYear($db, $annee);
                         <p><strong>Jours de vente :</strong> <?= $chargeTravail['total_sales_days'] ?></p>
                         <p><strong>Jours de collecte :</strong> <?= $chargeTravail['total_collection_days'] ?></p>
                         <p><strong>Heures de bénévolat :</strong> <?= $chargeTravail['benevolat_hours'] ?> h</p>
-                        <p><strong>Heures des salariés :</strong> <?= $chargeTravail['employee_hours'] ?> h</p>
+                        <p><strong>Heures des salariées - total (status 1 et 2) :</strong> <?= $chargeTravail['employee_hours'] ?> h</p>
+                        <p><strong>Heures des coordinatrices (status 1) :</strong> <?= $chargeTravail['employee_hours_coordinatrice'] ?> h</p>
+                        <p><strong>Heures des agents d'entretien (status 2) :</strong> <?= $chargeTravail['employee_hours_agent_entretien'] ?> h</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
### Motivation
- Fournir un rapport dédié de «Charge de travail» accessible depuis la page des bilans pour suivre les jours d'activité/vente/collecte et les heures (bénévolat vs salariés). 

### Description
- Ajout d'un lien dans `bilan.php` vers la nouvelle page `chargeTravail.php` pour l'année sélectionnée. 
- Création de la page `chargeTravail.php` qui charge l'année via `?annee=...`, protège l'accès avec la session admin et affiche les indicateurs demandés. 
- Ajout de la fonction `getChargeTravailStatsForYear()` dans `actions/comptabilite/bilanHelpers.php` qui calcule les jours totaux d'activité (`cat_creneau = 0`), les jours de vente en excluant les mardis (`DAYOFWEEK(start) <> 3`), les jours de collecte en excluant les semaines paires (parité de `WEEKOFYEAR`) et sépare les heures de bénévolat et des salariés via une jointure `LEFT JOIN employes` et `TIMESTAMPDIFF(... ) DIV 60`. 

### Testing
- Vérification de syntaxe PHP exécutée avec `php -l` pour `chargeTravail.php`, `bilan.php` et `actions/comptabilite/bilanHelpers.php`, toutes réussies.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc419ac0088327aec973eaf6b7ba4b)