### PR TITLE
Adapte le menu includes/nav.php pour les petits écrans

### DIFF
--- a/includes/nav.php
+++ b/includes/nav.php
@@ -3,22 +3,48 @@
 $mode_dev = false; // Toggle ici
 ?>
 
-<nav class="navforum">
-    <ul class="navforum_ul">
-        <li class="navforum_li <?php echo ($page == 1) ? 'vert' : 'bleu'; ?>"><a class="lien_li" href="depot.php">Collecte</a></li>
-        <li class="navforum_li <?php echo ($page == 2) ? 'vert' : 'bleu'; ?>"><a class="lien_li" href="accueil_vente.php">Vente</a></li>
-        <li class="navforum_li <?php echo ($page == 3) ? 'vert' : 'bleu'; ?>"><a class="lien_li" href="bilan.php">Bilans</a></li>
-        <li class="navforum_li <?php echo ($page == 4) ? 'vert' : 'bleu'; ?>"><a class="lien_li" href="reparation.php">Reparation</a></li>
-        <?php if (isset($_SESSION['admin']) && $_SESSION['admin'] >= 1): ?>
-            <li class="navforum_li <?php echo ($page == 5) ? 'vert' : 'bleu'; ?>"><a class="lien_li" href="administration.php">Administration</a></li>
-        <?php endif; ?>
-        
-        <?php if ($mode_dev): ?>
-            <li class="navforum_li orange"><a class="lien_li" href="test_debug.php">🧪 Tests</a></li>
-            <li class="navforum_li orange"><a class="lien_li" href="logs.php">📄 Logs</a></li>
-            <li class="navforum_li orange"><a class="lien_li" href="db_inspect.php">🗄️ DB Inspect</a></li>
-        <?php endif; ?>
-        
-        <li class="navforum_li bleu"><a class="lien_li" href="actions/users/logoutAction.php">Logout</a></li>     
-    </ul>
+<nav class="navbar navbar-expand-lg navforum px-2">
+    <div class="container-fluid">
+        <button class="navbar-toggler custom-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#menuForum" aria-controls="menuForum" aria-expanded="false" aria-label="Ouvrir le menu">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <div class="collapse navbar-collapse justify-content-center" id="menuForum">
+            <ul class="navbar-nav gap-2 text-center navforum_ul">
+                <li class="nav-item navforum_li">
+                    <a class="nav-link menu-btn <?= ($page == 1) ? 'active-link' : 'inactive-link' ?>" href="depot.php">Collecte</a>
+                </li>
+                <li class="nav-item navforum_li">
+                    <a class="nav-link menu-btn <?= ($page == 2) ? 'active-link' : 'inactive-link' ?>" href="accueil_vente.php">Vente</a>
+                </li>
+                <li class="nav-item navforum_li">
+                    <a class="nav-link menu-btn <?= ($page == 3) ? 'active-link' : 'inactive-link' ?>" href="bilan.php">Bilans</a>
+                </li>
+                <li class="nav-item navforum_li">
+                    <a class="nav-link menu-btn <?= ($page == 4) ? 'active-link' : 'inactive-link' ?>" href="reparation.php">Reparation</a>
+                </li>
+                <?php if (isset($_SESSION['admin']) && $_SESSION['admin'] >= 1): ?>
+                    <li class="nav-item navforum_li">
+                        <a class="nav-link menu-btn <?= ($page == 5) ? 'active-link' : 'inactive-link' ?>" href="administration.php">Administration</a>
+                    </li>
+                <?php endif; ?>
+
+                <?php if ($mode_dev): ?>
+                    <li class="nav-item navforum_li">
+                        <a class="nav-link menu-btn dev-link" href="test_debug.php">🧪 Tests</a>
+                    </li>
+                    <li class="nav-item navforum_li">
+                        <a class="nav-link menu-btn dev-link" href="logs.php">📄 Logs</a>
+                    </li>
+                    <li class="nav-item navforum_li">
+                        <a class="nav-link menu-btn dev-link" href="db_inspect.php">🗄️ DB Inspect</a>
+                    </li>
+                <?php endif; ?>
+
+                <li class="nav-item navforum_li">
+                    <a class="nav-link menu-btn inactive-link" href="actions/users/logoutAction.php">Logout</a>
+                </li>
+            </ul>
+        </div>
+    </div>
 </nav>

--- a/includes/nav.php
+++ b/includes/nav.php
@@ -51,47 +51,51 @@ $mode_dev = false; // Toggle ici
 
 <script>
 (function () {
-    const menu = document.getElementById('menuForum');
-    const toggle = document.getElementById('menuForumToggle');
+    function initNavAutoCollapse() {
+        const menu = document.getElementById('menuForum');
+        const toggle = document.getElementById('menuForumToggle');
 
-    if (!menu || !toggle || typeof bootstrap === 'undefined') {
-        return;
-    }
-
-    const collapse = bootstrap.Collapse.getOrCreateInstance(menu, { toggle: false });
-    let inactivityTimer = null;
-
-    function clearInactivityTimer() {
-        if (inactivityTimer) {
-            clearTimeout(inactivityTimer);
-            inactivityTimer = null;
+        if (!menu || !toggle || typeof bootstrap === 'undefined') {
+            return;
         }
-    }
 
-    function startInactivityTimer() {
-        clearInactivityTimer();
-        inactivityTimer = setTimeout(() => {
-            if (menu.classList.contains('show')) {
-                collapse.hide();
+        const collapse = bootstrap.Collapse.getOrCreateInstance(menu, { toggle: false });
+        let inactivityTimer = null;
+
+        function clearInactivityTimer() {
+            if (inactivityTimer) {
+                clearTimeout(inactivityTimer);
+                inactivityTimer = null;
             }
-        }, 5000);
-    }
-
-    function resetInactivityTimer() {
-        if (menu.classList.contains('show')) {
-            startInactivityTimer();
         }
+
+        function startInactivityTimer() {
+            clearInactivityTimer();
+            inactivityTimer = setTimeout(() => {
+                if (menu.classList.contains('show')) {
+                    collapse.hide();
+                }
+            }, 5000);
+        }
+
+        function resetInactivityTimer() {
+            if (menu.classList.contains('show')) {
+                startInactivityTimer();
+            }
+        }
+
+        menu.addEventListener('shown.bs.collapse', startInactivityTimer);
+        menu.addEventListener('hidden.bs.collapse', clearInactivityTimer);
+
+        ['click', 'touchstart', 'mousemove', 'keydown', 'scroll'].forEach((eventName) => {
+            menu.addEventListener(eventName, resetInactivityTimer);
+        });
+
+        toggle.addEventListener('click', () => {
+            setTimeout(resetInactivityTimer, 50);
+        });
     }
 
-    menu.addEventListener('shown.bs.collapse', startInactivityTimer);
-    menu.addEventListener('hidden.bs.collapse', clearInactivityTimer);
-
-    ['click', 'touchstart', 'mousemove', 'keydown', 'scroll'].forEach((eventName) => {
-        menu.addEventListener(eventName, resetInactivityTimer);
-    });
-
-    toggle.addEventListener('click', () => {
-        setTimeout(resetInactivityTimer, 50);
-    });
+    window.addEventListener('load', initNavAutoCollapse);
 })();
 </script>

--- a/includes/nav.php
+++ b/includes/nav.php
@@ -5,7 +5,7 @@ $mode_dev = false; // Toggle ici
 
 <nav class="navbar navbar-expand-lg navforum px-2">
     <div class="container-fluid">
-        <button class="navbar-toggler custom-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#menuForum" aria-controls="menuForum" aria-expanded="false" aria-label="Ouvrir le menu">
+        <button id="menuForumToggle" class="navbar-toggler custom-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#menuForum" aria-controls="menuForum" aria-expanded="false" aria-label="Ouvrir le menu">
             <span class="navbar-toggler-icon"></span>
         </button>
 
@@ -48,3 +48,50 @@ $mode_dev = false; // Toggle ici
         </div>
     </div>
 </nav>
+
+<script>
+(function () {
+    const menu = document.getElementById('menuForum');
+    const toggle = document.getElementById('menuForumToggle');
+
+    if (!menu || !toggle || typeof bootstrap === 'undefined') {
+        return;
+    }
+
+    const collapse = bootstrap.Collapse.getOrCreateInstance(menu, { toggle: false });
+    let inactivityTimer = null;
+
+    function clearInactivityTimer() {
+        if (inactivityTimer) {
+            clearTimeout(inactivityTimer);
+            inactivityTimer = null;
+        }
+    }
+
+    function startInactivityTimer() {
+        clearInactivityTimer();
+        inactivityTimer = setTimeout(() => {
+            if (menu.classList.contains('show')) {
+                collapse.hide();
+            }
+        }, 5000);
+    }
+
+    function resetInactivityTimer() {
+        if (menu.classList.contains('show')) {
+            startInactivityTimer();
+        }
+    }
+
+    menu.addEventListener('shown.bs.collapse', startInactivityTimer);
+    menu.addEventListener('hidden.bs.collapse', clearInactivityTimer);
+
+    ['click', 'touchstart', 'mousemove', 'keydown', 'scroll'].forEach((eventName) => {
+        menu.addEventListener(eventName, resetInactivityTimer);
+    });
+
+    toggle.addEventListener('click', () => {
+        setTimeout(resetInactivityTimer, 50);
+    });
+})();
+</script>

--- a/nav.css
+++ b/nav.css
@@ -5,6 +5,7 @@
   top: 0;
   background-color: #FBF3E4;
   min-height: 80px;
+  position: relative;
 }
 
 .navforum .container-fluid {
@@ -25,14 +26,17 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 160px;
-  min-height: 40px;
+  width: 170px;
+  min-width: 170px;
+  height: 44px;
   margin: 10px;
   border-radius: 5px;
   box-shadow: 0 0 5px black;
   font-weight: bold;
   text-decoration: none;
   color: white;
+  white-space: nowrap;
+  padding: 0 10px;
 }
 
 .navforum .menu-btn:hover {
@@ -141,6 +145,7 @@
 @media (max-width: 991.98px) {
   .navforum {
     min-height: auto;
+    padding-top: 56px;
   }
 
   .navforum .navbar-collapse {
@@ -149,7 +154,18 @@
 
   .navforum .menu-btn {
     width: 100%;
+    min-width: 100%;
+    height: 44px;
     margin: 4px 0;
+  }
+
+  .custom-toggler {
+    position: fixed;
+    top: 8px;
+    left: 8px;
+    margin: 0;
+    z-index: 1080;
+    background-color: #FBF3E4;
   }
 }
 

--- a/nav.css
+++ b/nav.css
@@ -152,6 +152,11 @@
     padding-bottom: 8px;
   }
 
+  .navforum .navforum_ul,
+  .navforum .navforum_li {
+    width: 100%;
+  }
+
   .navforum .menu-btn {
     width: 100%;
     min-width: 100%;
@@ -161,7 +166,7 @@
 
   .custom-toggler {
     position: fixed;
-    top: 8px;
+    top: 160px;
     left: 8px;
     margin: 0;
     z-index: 1080;

--- a/nav.css
+++ b/nav.css
@@ -1,60 +1,87 @@
 @charset "UTF-8";
+
 .navforum {
   width: 100%;
-  height: 80px;
-  /*le TOP permet d'avoir la position sticky qui vient à 0px du haut, soit collé en haut du navigateur. */
-  /*Peut-être à faire évoluer pour un affichage sur petit écran*/
-  top: 0px;
+  top: 0;
   background-color: #FBF3E4;
+  min-height: 80px;
+}
+
+.navforum .container-fluid {
+  justify-content: center;
+}
+
+.navforum .navforum_ul {
+  padding: 0;
+  align-items: center;
+  justify-content: center;
+}
+
+.navforum .navforum_li {
+  list-style-type: none;
+}
+
+.navforum .menu-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 160px;
+  min-height: 40px;
+  margin: 10px;
+  border-radius: 5px;
+  box-shadow: 0 0 5px black;
+  font-weight: bold;
+  text-decoration: none;
+  color: white;
+}
+
+.navforum .menu-btn:hover {
+  color: white;
+}
+
+.custom-toggler {
+  border: 2px solid #23A3D9;
+  margin: 8px auto;
+}
+
+.custom-toggler .navbar-toggler-icon {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%2835, 163, 217, 0.95%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2.5' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+}
+
+.inactive-link {
+  background-color: #23A3D9;
+}
+
+.active-link {
+  background-color: #26A648;
+}
+
+.dev-link {
+  background-color: #f39c12;
+}
+
+.inactive-link:hover {
+  background-color: #26A648;
+}
+
+.active-link:hover {
+  background-color: #23A3D9;
+}
+
+.dev-link:hover {
+  background-color: #e67e22;
 }
 
 .navvente {
   margin-bottom: 10px;
   width: 100%;
   height: 40px;
-  /*le TOP permet d'avoir la position sticky qui vient à 80px du haut, soit sous navforum. */
-  /*Peut-être à faire évoluer pour un affichage sur petit écran*/
   top: 80px;
   background-color: #FBF3E4;
 }
 
-.navforum > .navforum_ul {
-  padding: 0px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.navforum > .navforum_ul > .navforum_li {
-  display: flex;
-  list-style-type: none;
-  width: 160px;
-  height: 40px;
-  box-shadow: 0px 0px 5px black;
-  font-weight: bold;
-  border-radius: 5px;
-  margin: 10px 10px;
-  align-items: center;
-  justify-content: center;
-  color: white;
-}
-
-.navforum .navforum_ul .navforum_li {
-  position: relative;
-}
-
-.navforum > .navforum_ul > .navforum_li > .lien_li {
-  display: block;
-  width: 100%;
-  margin: 0px;
-  padding: 0px;
-  text-align: center;
-  text-decoration: none;
-  color: white;
-}
-
 .navvente > .navvente_ul {
-  padding: 0px;
+  padding: 0;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -65,10 +92,10 @@
   list-style-type: none;
   width: 160px;
   height: 20px;
-  box-shadow: 0px 0px 5px black;
+  box-shadow: 0 0 5px black;
   font-weight: bold;
   border-radius: 5px;
-  margin: 0px 10px;
+  margin: 0 10px;
   align-items: center;
   justify-content: center;
   color: white;
@@ -81,14 +108,14 @@
 .navvente > .navvente_ul > .navvente_li > .lien_li {
   display: block;
   width: 100%;
-  margin: 0px;
-  padding: 0px;
+  margin: 0;
+  padding: 0;
   text-align: center;
   text-decoration: none;
   color: white;
 }
 
-/* Pour faire en sorte que l'écriture dans les boutons soit centrée et la couleur des boutons*/
+/* Classes historiques conservées pour compatibilité */
 .bleu {
   background-color: #23A3D9;
 }
@@ -103,11 +130,27 @@
   color: white;
 }
 
-/*Pour faire changer la couleur des boutons lors du survol de la souris*/
 .bleu:hover {
   background-color: #26A648;
 }
 
 .vert:hover {
   background-color: #23A3D9;
-}/*# sourceMappingURL=nav.css.map */
+}
+
+@media (max-width: 991.98px) {
+  .navforum {
+    min-height: auto;
+  }
+
+  .navforum .navbar-collapse {
+    padding-bottom: 8px;
+  }
+
+  .navforum .menu-btn {
+    width: 100%;
+    margin: 4px 0;
+  }
+}
+
+/*# sourceMappingURL=nav.css.map */

--- a/nav.css
+++ b/nav.css
@@ -146,6 +146,13 @@
   .navforum {
     min-height: auto;
     padding-top: 56px;
+    position: sticky;
+    top: 0;
+    z-index: 1070;
+  }
+
+  .navforum .container-fluid {
+    position: relative;
   }
 
   .navforum .navbar-collapse {
@@ -165,8 +172,8 @@
   }
 
   .custom-toggler {
-    position: fixed;
-    top: 160px;
+    position: absolute;
+    top: 8px;
     left: 8px;
     margin: 0;
     z-index: 1080;


### PR DESCRIPTION
### Motivation
- Rendre le menu principal utilisable sur petits écrans en reprenant l'approche responsive (menu repliable) du dépôt de référence tout en conservant la logique existante des onglets actifs et des accès admin/dev.

### Description
- Remplacement de la structure statique par une `navbar` responsive (bouton toggler + `collapse`) dans `includes/nav.php` tout en conservant les conditions `$_SESSION['admin']` et `$mode_dev` pour les liens spéciaux.
- Introduction de nouvelles classes utilitaires (`menu-btn`, `active-link`, `inactive-link`, `dev-link`, `custom-toggler`) et conservation des classes historiques (`bleu`, `vert`, `active`) pour compatibilité avec le reste du projet.
- Mise à jour de `nav.css` pour styler le toggler, les états de boutons et ajouter une `@media` pour l'affichage mobile (largeur <= 991.98px) qui rend les boutons pleine largeur.
- Modifications effectuées sur les fichiers `includes/nav.php` et `nav.css` uniquement, sans modification fonctionnelle de `includes/nav_vente.php`.

### Testing
- Vérification syntaxique PHP exécutée avec `php -l includes/nav.php` et la commande a réussi (pas d'erreurs de syntaxe). 
- Vérification syntaxique PHP exécutée avec `php -l includes/nav_vente.php` et la commande a réussi (pas d'erreurs de syntaxe).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd42286ac083279fb89adbe9aef1bc)